### PR TITLE
Fix groovy tests by compiling jvm classes

### DIFF
--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -82,6 +82,8 @@ sourceSets {
     }
 }
 
+test.dependsOn compileKotlinJvm
+
 // workaround for https://youtrack.jetbrains.com/issue/KT-27170
 configurations {
     compileClasspath


### PR DESCRIPTION
Even if the goal is to migrate from GoovyTest to Kotlin test, the actual tests should continue to work until the migration is completed.

We correct the groovy tests by making sure jvmClasses are compiled so Groovy tests can find them in the build classpath