### PR TITLE
Modify AbstractAttachable to only cancel the previous CancellableManager on detach

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/attachable/AbstractAttachable.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/attachable/AbstractAttachable.kt
@@ -36,7 +36,7 @@ abstract class AbstractAttachable(private val maxSimultaneousAttachCount: Int = 
 
         if (newattachCount == 0) {
             doDetach()
-            cancellableManagerProvider.cancel()
+            cancellableManagerProvider.cancelPreviousAndCreate()
         }
     }
 


### PR DESCRIPTION
The `AbstractAttachable` class now permit to reattach since the provider is not in a cancel state anymore.