### PR TITLE
Add SourcedPublisher

### DIFF
--- a/documentation/PUBLISHERS.md
+++ b/documentation/PUBLISHERS.md
@@ -97,6 +97,21 @@ ColdPublisher({ cancelableManager ->
 })
 ```
 
+### SourcedPublisher
+Sourced publisher publishes a value from another publisher. The source publisher can be switched if needed. Like all publishers, subscribes on the source Publisher when a subscription is active on the SourcedPublisher.
+
+```kotlin
+val sourcedPublisher = SourcedPublisher(null)
+myPublisher.subscribe(cancellableManager) { print(it) }
+sourcedPublisher.source = publisherFactory.create(false)
+sourcedPublisher.source = publisherFactory.create(true)
+```
+*Output*
+```
+false
+true
+```
+
 ### CombineLatest
 CombineLatest combines the result of up to 5 publishers and dispatch them when all publishers have a value. CombineLatest values are destructurizable data class. Use the provided companion object to create a new CombineLatest publisher: `CombineLatest.combine[X](...): CombineLatest`
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/SourcedPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/SourcedPublisher.kt
@@ -1,0 +1,37 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
+import com.mirego.trikot.streams.concurrent.AtomicReference
+import org.reactivestreams.Publisher
+
+class SourcedPublisher<T>(value: T) : SimplePublisher<T>(value) {
+    private val sourceRef = AtomicReference<Publisher<T>?>(null)
+    private val cancellableManagerProvider = CancellableManagerProvider()
+
+    var source: Publisher<T>?
+        get() = sourceRef.value
+        set(value) {
+            sourceRef.setOrThrow(sourceRef.value, value)
+            subscribeIfNeeded()
+        }
+
+    override fun onFirstSubscription() {
+        super.onFirstSubscription()
+        subscribeIfNeeded()
+    }
+
+    override fun onNoSubscription() {
+        super.onNoSubscription()
+        cancellableManagerProvider.cancelPreviousAndCreate()
+    }
+
+    private fun subscribeIfNeeded() {
+        if (hasSubscriptions) {
+            source?.let { publisher ->
+                publisher.subscribe(cancellableManagerProvider.cancelPreviousAndCreate()) {
+                    value = it
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The motivation behind SourcedPublisher is to allow the source of a value to be changed without forcing the UI to resubscribe.

As an example, we might want to change the value of a publisher every time the user perform an action.

```kotlin
val sourcedPublisher = SourcedPublisher(<Initial Value>)

fun doUpdateString() {
  sourcedPublisher.source = doGetNewExecutablePublisher().also { it.execute() } 
}
```
