### PR TITLE
Fix shared processor last value race condition

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
@@ -17,6 +17,8 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : SimplePubl
 
     override fun onNoSubscription() {
         super.onNoSubscription()
+        value = null
+        error = null
         cancellableManagerProvider.cancelPreviousAndCreate()
     }
 


### PR DESCRIPTION
When shared processor does not have any subscriber, the parentPublisher does not emit the new value the the shared processor.

This fix makes sure the first value we receive from a shared publisher is fresh.