### PR TITLE
Fix shareProcessor completed state

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/BehaviorSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/BehaviorSubjectImpl.kt
@@ -8,8 +8,8 @@ open class BehaviorSubjectImpl<T>(
         this.value = initialValue
     }
 
-    override fun addSubscription(subscription: PublisherSubscription<T>) {
-        super.addSubscription(subscription)
+    override fun onNewSubscription(subscription: PublisherSubscription<T>) {
+        super.onNewSubscription(subscription)
         if (!subscription.isCancelled) {
             this.value?.let { subscription.dispatchValue(it) }
             this.error?.let { subscription.dispatchError(it) }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
@@ -58,7 +58,8 @@ open class PublishSubjectImpl<T> : PublishSubject<T> {
         if (subscriptions.remove(publisherSubscription).isEmpty()) onNoSubscription()
     }
 
-    protected open fun addSubscription(subscription: PublisherSubscription<T>) {
+    private fun addSubscription(subscription: PublisherSubscription<T>) {
+        onNewSubscription(subscription)
         if (!subscription.isCancelled) {
             if (this.completed) {
                 subscription.dispatchCompleted()
@@ -66,6 +67,9 @@ open class PublishSubjectImpl<T> : PublishSubject<T> {
                 onFirstSubscription()
             }
         }
+    }
+
+    protected open fun onNewSubscription(subscription: PublisherSubscription<T>) {
     }
 
     protected open fun dispatchValueToSubscribers(value: T) {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
@@ -17,8 +17,10 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : BehaviorSu
 
     override fun onNoSubscription() {
         super.onNoSubscription()
-        value = null
-        error = null
+        if (!completed) {
+            value = null
+            error = null
+        }
         cancellableManagerProvider.cancelPreviousAndCreate()
     }
 


### PR DESCRIPTION
When a shared publisher receive a completed state, it must not "clear" its values on the last unSubscription for 2 reason:
- We received an ended state, the result is omnipotent and will never change (Optimisation)
- AbstractProcessor will fail (crash) to update its value after a completed state is set