### PR TITLE
Add switchmap completed state

### DIFF
--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.streams.reactive.processors
 
+import com.mirego.trikot.streams.cancellable.Cancellable
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import com.mirego.trikot.streams.reactive.Publishers
@@ -8,6 +9,7 @@ import com.mirego.trikot.streams.reactive.switchMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SwitchMapProcessorTests {
     @Test
@@ -41,6 +43,40 @@ class SwitchMapProcessorTests {
         cancellableManager.cancel()
 
         assertFalse { returnedPublisher.getHasSubscriptions }
+    }
+
+    @Test
+    fun whenSwitchMappedIsCompletedAndProvidedNotCompletedThenNotCompleted() {
+        val switchMappedPublisher = Publishers.behaviorSubject("a")
+        val returnedPublisher = Publishers.behaviorSubject("b")
+        var isCompleted = false
+
+        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(CancellableManager(), onNext = {}, onError = {}, onCompleted = {isCompleted = true})
+        switchMappedPublisher.complete()
+        assertFalse { isCompleted }
+    }
+
+    @Test
+    fun whenSwitchMappedIsNotCompletedAndProvidedIsCompletedThenNotCompleted() {
+        val switchMappedPublisher = Publishers.behaviorSubject("a")
+        val returnedPublisher = Publishers.behaviorSubject("b")
+        var isCompleted = false
+
+        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(CancellableManager(), onNext = {}, onError = {}, onCompleted = {isCompleted = true})
+        returnedPublisher.complete()
+        assertFalse { isCompleted }
+    }
+
+    @Test
+    fun whenSwitchMappedIsCompletedAndProvidedIsCompletedThenCompleted() {
+        val switchMappedPublisher = Publishers.behaviorSubject("a")
+        val returnedPublisher = Publishers.behaviorSubject("b")
+        var isCompleted = false
+
+        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(CancellableManager(), onNext = {}, onError = {}, onCompleted = {isCompleted = true})
+        switchMappedPublisher.complete()
+        returnedPublisher.complete()
+        assertTrue { isCompleted }
     }
 
     class MockPublisher : BehaviorSubjectImpl<String>("a") {


### PR DESCRIPTION
This PR implements the SwitchMap completion state (Parent and Block publisher are completed).

iOS do not retain the publisher returned by the `block(t)`. To prevent this, we keep a reference (in `currentPublisher`) to the last provided publisher.
