### PR TITLE
Fix: combined publishers don’t notify all values

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -3,13 +3,15 @@ package com.mirego.trikot.streams.reactive.processors
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
-import com.mirego.trikot.streams.reactive.map
 import com.mirego.trikot.streams.reactive.subscribe
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class CombineLatestProcessor<T>(parentPublisher: Publisher<T>, private val publishers: List<Publisher<T>>) :
+class CombineLatestProcessor<T>(
+    parentPublisher: Publisher<T>,
+    private val publishers: List<Publisher<T>>
+) :
     AbstractProcessor<T, List<T?>>(parentPublisher) {
 
     override fun createSubscription(subscriber: Subscriber<in List<T?>>): ProcessorSubscription<T, List<T?>> {
@@ -34,10 +36,12 @@ class CombineLatestProcessor<T>(parentPublisher: Publisher<T>, private val publi
             publishersResult.removeAll(publishersResult.value)
 
             publishersResult.add(PublisherResult<T>().also { it.value = t })
+            repeat(publishers.size) {
+                publishersResult.add(PublisherResult())
+            }
 
             publishers.forEachIndexed { index, publisher ->
                 val publisherResultIndex = index + 1
-                publishersResult.add(PublisherResult())
                 publisher.subscribe(cancellableManager,
                     onNext = { updatePublisherResultValue(publisherResultIndex, it) },
                     onError = { onError(it) },

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
@@ -31,17 +31,21 @@ class CombineLatestProcessorTests {
     fun valuesAreDispatchedWhenAllPublishersEmits() {
         val firstPublisher = MockPublisher("a")
         val secondPublisher = MockPublisher("b")
+        val thirdPublisher = MockPublisher("c")
         var firstValueReceived: String? = null
         var secondValueReceived: String? = null
+        var thirdValueReceived: String? = null
 
-        firstPublisher.combine(secondPublisher)
-            .subscribe(CancellableManager()) { (value1, value2) ->
+        firstPublisher.combine(listOf(secondPublisher, thirdPublisher))
+            .subscribe(CancellableManager()) { (value1, value2, value3) ->
                 firstValueReceived = value1
                 secondValueReceived = value2
+                thirdValueReceived = value3
             }
 
         assertEquals("a", firstValueReceived)
         assertEquals("b", secondValueReceived)
+        assertEquals("c", thirdValueReceived)
     }
 
     @Test
@@ -53,7 +57,8 @@ class CombineLatestProcessorTests {
         var valuesReceived: List<String?>? = null
         var completed = false
 
-        combine(listOf(firstPublisher, secondPublisher, thirdPublisher)).subscribe(CancellableManager(),
+        combine(listOf(firstPublisher, secondPublisher, thirdPublisher)).subscribe(
+            CancellableManager(),
             onNext = { valuesReceived = it },
             onError = {},
             onCompleted = { completed = true }


### PR DESCRIPTION
Also adding a third `Publisher` in `valuesAreDispatchedWhenAllPublishersEmits` to handle this case