### PR TITLE
Fix combine latest reemission on complete

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ColdPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ColdPublisher.kt
@@ -12,9 +12,16 @@ class ColdPublisher<T>(private val executionBlock: ColdPublisherExecutionBlock<T
     override fun onFirstSubscription() {
         super.onFirstSubscription()
         val cancellableManager = cancellableManagerProvider.cancelPreviousAndCreate()
-        executionBlock(cancellableManager).subscribe(cancellableManager) {
+        executionBlock(cancellableManager).subscribe(cancellableManager,
+            onNext = {
                 executionValue -> value = executionValue
-        }
+            },
+            onError = {
+                error = it
+            },
+            onCompleted = {
+                complete()
+            })
     }
 
     override fun onNoSubscription() {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,5 +1,7 @@
 package com.mirego.trikot.streams.reactive
 
+import org.reactivestreams.Publisher
+
 object Publishers {
     fun <T> behaviorSubject(value: T? = null): BehaviorSubject<T> {
         return BehaviorSubjectImpl(value)
@@ -7,5 +9,17 @@ object Publishers {
 
     fun <T> publishSubject(): PublishSubject<T> {
         return PublishSubjectImpl()
+    }
+
+    fun <T> just(value: T): Publisher<T> {
+        return behaviorSubject(value).also { it.complete() }
+    }
+
+    fun <T> empty(): Publisher<T> {
+        return PublishSubjectImpl()
+    }
+
+    fun <T> completed(): Publisher<T> {
+        return PublishSubjectImpl<T>().also { it.complete() }
     }
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -62,7 +62,7 @@ class CombineLatestProcessor<T>(
 
         private fun markPublisherResultCompleted(publisherResultIndex: Int) {
             publishersResult.value[publisherResultIndex].completed = true
-            dispatchResultIfNeeded()
+            dispatchResultIfNeeded(true)
         }
 
         private fun updatePublisherResultValue(publisherResultIndex: Int, value: T) {
@@ -74,7 +74,7 @@ class CombineLatestProcessor<T>(
             markPublisherResultCompleted(parentPublisherResultIndex)
         }
 
-        fun dispatchResultIfNeeded() {
+        private fun dispatchResultIfNeeded(forPublisherCompletion: Boolean = false) {
             var allValues = true
             var allCompleted = true
             publishersResult.value.forEach publishersLoop@{
@@ -84,9 +84,13 @@ class CombineLatestProcessor<T>(
                     return@publishersLoop
                 }
             }
-            if (allValues || allCompleted) {
+
+            if (allValues && !forPublisherCompletion) {
+                dispatchResult()
+            } else if (allCompleted && !allValues) {
                 dispatchResult()
             }
+
             if (allCompleted) {
                 subscriber.onComplete()
             }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
@@ -131,6 +131,20 @@ class CombineLatestProcessorTests {
         assertFalse { secondPublisher.getHasSubscriptions }
     }
 
+    @Test
+    fun valuesAreNotReemittedOnCompletion() {
+        val firstPublisher = MockPublisher("a")
+        val secondPublisher = MockPublisher("b")
+        firstPublisher.complete()
+        secondPublisher.complete()
+
+        var callbackCount = 0
+        firstPublisher.combine(secondPublisher).subscribe(CancellableManager()) {
+            callbackCount++
+        }
+        assertEquals(1, callbackCount)
+    }
+
     class MockPublisher(initialValue: String? = null) : BehaviorSubjectImpl<String>(initialValue) {
         val getHasSubscriptions get() = super.hasSubscriptions
     }


### PR DESCRIPTION
This fixes two issues:
- `CombineLatest` was reemitting the values when all publishers was completed. Now it only emit the values if all publishers are completed and we don't have all the values
- `ColdPublisher` was not bubbling `error` and `completion` state