### PR TITLE
Freeze CancellableManager in CancellableManagerProvider

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -1,9 +1,10 @@
 package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.MrFreeze
 
 class CancellableManagerProvider : Cancellable {
-    private val cancellableManager = CancellableManager()
+    private val cancellableManager = MrFreeze.freeze(CancellableManager())
     private val internalCancellableManagerRef =
         AtomicReference(CancellableManager())
 


### PR DESCRIPTION
## Description
We now freeze the CancellableManager

## Motivation and Context
When using ColdPublisher (That uses the CancellableManagerProvider under the hood) in iOS, we sometimes had that exception:

```
Uncaught Kotlin exception: kotlin.native.IncorrectDereferenceException: illegal attempt to access non-shared com.mirego.trikot.streams.cancellable.CancellableManager@83585ee8 from other thread
```

## How Has This Been Tested?
It has been tested in our app with our Storage implementation. Before this fix, the exception was raised anytime we were trying to list files.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
