### PR TITLE
Do not keep subscription active when cancelled in new subscription callback

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
@@ -63,10 +63,12 @@ open class PublishSubjectImpl<T> : PublishSubject<T> {
     private fun addSubscription(subscription: PublisherSubscription<T>) {
         if (!subscription.isCancelled) {
             onNewSubscription(subscription)
-            if (this.completed) {
-                subscription.dispatchCompleted()
-            } else if (subscriptions.add(subscription).count() == 1) {
-                onFirstSubscription()
+            if (!subscription.isCancelled) {
+                if (this.completed) {
+                    subscription.dispatchCompleted()
+                } else if (subscriptions.add(subscription).count() == 1) {
+                    onFirstSubscription()
+                }
             }
         }
     }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectTests.kt
@@ -86,6 +86,29 @@ class PublishSubjectTests {
         }
     }
 
+    @Test
+    fun subscriberIsNotAddedToListWhenIsCancellationOccursInNewSubscriptionCallback() {
+        val publisher1 = PublishSubjectMock<String>()
+        val publisher2 = PublishSubjectMock<String>()
+        var completed = false
+        publisher1
+            .switchMap { publisher2 }
+            .first()
+            .subscribe(CancellableManager(), onNext = {
+            }, onError = {},
+                onCompleted = { completed = true })
+        publisher1.value = "1"
+        publisher2.value = "2"
+
+        assertTrue { completed }
+        assertTrue { publisher1.hasNoSubscription }
+        assertTrue { publisher2.hasNoSubscription }
+    }
+
+    class PublishSubjectMock<T>() : PublishSubjectImpl<T>() {
+        val hasNoSubscription get() = !super.hasSubscriptions
+    }
+
     fun retreiveValue(block: (String) -> Unit, cancellableManager: CancellableManager = CancellableManager()) {
         publishSubject.first().subscribe(cancellableManager, block)
     }


### PR DESCRIPTION
## Motivation and Context
When the subscription is `cancelled` in the initial newSubcriptionCallback (mostly when used in a processor that complete the result), the `subscriber` is still added to the list and causes parent not to unsubscribe from the source.

The test and the code changes are too simple to go further in this description ;)

## How Has This Been Tested?
- Initially reproduced with the added test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
