### PR TITLE
Add serial operation queues for PublishSubject, CombineLatest and Switchmap

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.3.50
 kotlin.native.version=1.3.50
-trikot_foundation_version=0.7.1
+trikot_foundation_version=0.12.1
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
@@ -1,7 +1,11 @@
 package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.dispatch
+import com.mirego.trikot.foundation.concurrent.freeze
 import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
+import com.mirego.trikot.streams.reactive.observeOn
 import com.mirego.trikot.streams.reactive.subscribe
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
@@ -25,6 +29,7 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
         private val isChildCompleted = AtomicReference<Boolean>(false)
         private val currentPublisher = AtomicReference<Publisher<R>?>(null)
         private val onNextValidation = AtomicReference(0)
+        private val serialQueue = freeze(SynchronousSerialQueue())
 
         override fun onCancel(s: Subscription) {
             super.onCancel(s)
@@ -33,7 +38,9 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
 
         override fun onComplete() {
             isCompleted.setOrThrow(false, true)
-            dispatchCompletedIfNeeded()
+            serialQueue.dispatch {
+                dispatchCompletedIfNeeded()
+            }
         }
 
         override fun onNext(t: T, subscriber: Subscriber<in R>) {
@@ -42,7 +49,7 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
 
             val newPublisher = block(t)
             currentPublisher.setOrThrow(currentPublisher.value, newPublisher)
-            newPublisher.subscribe(cancellableManagerProvider.cancelPreviousAndCreate(),
+            newPublisher.observeOn(serialQueue).subscribe(cancellableManagerProvider.cancelPreviousAndCreate(),
                 onNext = { subscriber.onNext(it) },
                 onError = { subscriber.onError(it) },
                 onCompleted = {

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ObserveOnProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ObserveOnProcessorTests.kt
@@ -15,7 +15,8 @@ class ObserveOnProcessorTests {
         val dispatchQueue = DispatchQueueMock()
         val publisher = Publishers.behaviorSubject("a")
 
-        publisher.observeOn(dispatchQueue).subscribe(CancellableManager()) {}
+        val observeOn = publisher.observeOn(dispatchQueue)
+        observeOn.subscribe(CancellableManager()) {}
 
         assertNotNull(dispatchQueue.block)
     }


### PR DESCRIPTION
## Description
- Add a serial queue on PublishSubject Subcriptions, Unsubscriptions, value and error set
- Add a serial queue on CombineLatest subscriptions
- Add a serial queue on SwitchMap subscription

## Motivation and Context
Based on this text from http://reactivex.io/documentation/contract.html
```Observables must issue notifications to observers serially (not in parallel). They may issue these notifications from different threads, but there must be a formal happens-before relationship between the notifications.```

## How Has This Been Tested?
As it is almost impossible to test this, I tested in in my current project which is really highly sensible to race condition. It passes 100% of the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)
