### PR TITLE
Fix pod URL in Swift extensions documentation

### DIFF
--- a/swift-extensions/README.md
+++ b/swift-extensions/README.md
@@ -9,7 +9,7 @@ To use `Trikot.streams` swift extensions, you must export `streams` and `streams
 ##### Setup Pod dependency
 ```groovy
   ENV['TRIKOT_FRAMEWORK_NAME']='ReplaceMeByTheFrameworkNameImportedByCocoaPods'
-  pod 'Trikot.streams', :git => 'git@github.com:mirego/trikot.streams.git'
+  pod 'Trikot.streams', :git => 'https://github.com/mirego/trikot.streams.git'
 ```
 Then, run `pod install`.
 


### PR DESCRIPTION
## Description

GitHub [recommends using a repo’s HTTPS URL](https://help.github.com/en/github/using-git/which-remote-url-should-i-use#cloning-with-https-urls-recommended) when cloning it.

And since `trikot.streams` is a public repository, we should use this URL in our documentation.