### PR TITLE
CombineProcessor subscriptions subscribe on combinedProcessors on init

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -31,6 +31,10 @@ class CombineLatestProcessor<T>(
         private val parentPublisherResultIndex = 0
         private val serialQueue = freeze(SynchronousSerialQueue())
 
+        init {
+            subscribeToCombinedPublishersIfNeeded()
+        }
+
         override fun onCancel(s: Subscription) {
             super.onCancel(s)
             cancellableManagerProvider.cancel()


### PR DESCRIPTION
## Description
For performance reason, we subscribe directly on the init to the combined processor.

## Motivation and Context
The case is the following:
- ParentPublisher takes 2 seconds
- CombinedPublishes takes 2 seconds

Total time = 4 seconds as we subscribe when parentPublisher emit a value.

With the following change, 2 seconds will be necessary.

## How Has This Been Tested?
- Unit tests still passes

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
