### PR TITLE
Add StreamsProcessorException

### DIFF
--- a/documentation/PUBLISHERS.md
+++ b/documentation/PUBLISHERS.md
@@ -258,7 +258,7 @@ combine(listOf(publisher1, publisher2, publisher3)).subscribe(cancellableManager
 -> "a b c"
 
 ## Exceptions
-Exception are not handled by default in Trikot.streams. To enforce that developers are handling exceptions the right way, they must explicitely catch their exception in the processors block and throw a  
+Exceptions are not handled by default in `Trikot.streams`. To enforce that developers are handling exceptions the right way, they must explicitly catch their exceptions in the processors block and throw a  
 `StreamsProcessorException`. This will result in dispatching an OnError to all Subscribers.    
 
 Following code will crash

--- a/documentation/PUBLISHERS.md
+++ b/documentation/PUBLISHERS.md
@@ -256,3 +256,33 @@ combine(listOf(publisher1, publisher2, publisher3)).subscribe(cancellableManager
 }
 ```
 -> "a b c"
+
+## Exceptions
+Exception are not handled by default in Trikot.streams. To enforce that developers are handling exceptions the right way, they must explicitely catch their exception in the processors block and throw a  
+`StreamsProcessorException`. This will result in dispatching an OnError to all Subscribers.    
+
+Following code will crash
+```kotlin
+publisher1
+    .map { throw Exception() }
+    .subscribe(cancellableManager, 
+            onNext = {}, 
+            onError = { println(it) } 
+        )
+```
+
+Following code will print the exception
+```kotlin
+publisher1
+    .map { 
+        try { 
+            throw Exception() 
+        } catch(e: Exception) { 
+            throw StreamsProcessorException(e) 
+        } 
+    }
+    .subscribe(cancellableManager, 
+        onNext = {}, 
+        onError = { println(it) } 
+    )
+```

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/StreamsProcessorException.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/StreamsProcessorException.kt
@@ -1,0 +1,3 @@
+package com.mirego.trikot.streams.reactive
+
+class StreamsProcessorException(message: String? = null, cause: Throwable? = null) : Exception(message, cause)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessor.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.streams.reactive.processors
 
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 
@@ -17,7 +18,13 @@ class MapProcessor<T, R>(parentPublisher: Publisher<T>, private val block: MapPr
         private val block: MapProcessorBlock<T, R>
     ) : ProcessorSubscription<T, R>(subscriber) {
         override fun onNext(t: T, subscriber: Subscriber<in R>) {
-            subscriber.onNext(block(t))
+            val result = try {
+                block(t)
+            } catch (exception: StreamsProcessorException) {
+                onError(exception)
+                return
+            }
+            subscriber.onNext(result)
         }
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessorTests.kt
@@ -2,10 +2,12 @@ package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
 import com.mirego.trikot.streams.reactive.map
 import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class MapProcessorTests {
     @Test
@@ -19,5 +21,28 @@ class MapProcessorTests {
         }
 
         assertEquals(expectedResult, receivedResult)
+    }
+
+    @Test
+    fun testMappingStreamsProcessorException() {
+        val publisher = Publishers.behaviorSubject("a")
+        val expectedException = StreamsProcessorException()
+        var receivedException: StreamsProcessorException? = null
+
+        publisher.map { throw expectedException }.subscribe(CancellableManager(), onNext = {
+        }, onError = { receivedException = it as StreamsProcessorException })
+
+        assertEquals(expectedException, receivedException)
+    }
+
+    @Test
+    fun testMappingAnyException() {
+        val publisher = Publishers.behaviorSubject("a")
+        var receivedException: StreamsProcessorException? = null
+
+        assertFailsWith(IllegalStateException::class) {
+            publisher.map { throw IllegalStateException() }.subscribe(CancellableManager(), onNext = {
+            }, onError = { receivedException = it as StreamsProcessorException })
+        }
     }
 }


### PR DESCRIPTION
Add the possibility of switching from a `onNext` to an `onError`.

## Description
This provides a way to handle exceptions in processors like `map` and `switchMap`. However, this make sure that de developer explicitly catches exceptions by not catching all exceptions.

## How Has This Been Tested?
See updated test cases

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
