### PR TITLE
Make sure Publisher does not dispatch when subscription is cancelled

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherSubscription.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherSubscription.kt
@@ -21,17 +21,23 @@ open class PublisherSubscription<T>(
     }
 
     fun dispatchValue(value: T) {
-        subscriber.onNext(value)
+        if (!isCancelled) {
+            subscriber.onNext(value)
+        }
     }
 
     fun dispatchError(error: Throwable) {
-        cancel()
-        subscriber.onError(error)
+        if (!isCancelled) {
+            cancel()
+            subscriber.onError(error)
+        }
     }
 
     fun dispatchCompleted() {
-        cancel()
-        subscriber.onComplete()
+        if (!isCancelled) {
+            cancel()
+            subscriber.onComplete()
+        }
     }
 
     override fun request(n: Long) {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
@@ -14,9 +14,9 @@ class FirstProcessor<T>(parentPublisher: Publisher<T>) :
 
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             if (t != null) {
+                cancelActiveSubscription()
                 subscriber.onNext(t)
                 subscriber.onComplete()
-                cancelActiveSubscription()
             }
         }
     }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
@@ -14,8 +14,10 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : BehaviorSu
 
     override fun onFirstSubscription() {
         super.onFirstSubscription()
-        subscriptionCancellableManager.setOrThrow(subscriptionCancellableManager.value, cancellableManagerProvider.cancelPreviousAndCreate())
-        parentPublisher.subscribe(this)
+        if (!completed) {
+            subscriptionCancellableManager.setOrThrow(subscriptionCancellableManager.value, cancellableManagerProvider.cancelPreviousAndCreate())
+            parentPublisher.subscribe(this)
+        }
     }
 
     override fun onNoSubscription() {
@@ -32,5 +34,8 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : BehaviorSu
 
     override fun onError(t: Throwable) = let { error = t }
 
-    override fun onComplete() = complete()
+    override fun onComplete() {
+        cancellableManagerProvider.cancelPreviousAndCreate()
+        complete()
+    }
 }


### PR DESCRIPTION
## Description
`SharedProcessor` - Do not resubscribe to parentPublisher when completed
`FirstProcessor` - CancelActiveSubscription before calling onNext and onComplete
`PublisherSubscription` - Make sure not to dispatch events when cancelled

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
