### PR TITLE
Add Concat processor and test helpers

### DIFF
--- a/documentation/PUBLISHERS.md
+++ b/documentation/PUBLISHERS.md
@@ -207,6 +207,21 @@ uppercasePublisher.subscribe(...)
 ```
 In this case,  when fooPublisher emit a new value, the maps will only be executed once.
 
+
+#### Concat processor
+Emits the values of the first publisher until it completes. Then emits the values for the nextPublisher.
+```kotlin
+val firstPublisher = Publishers.behaviorSubject("i")
+val nextPublisher = Publishers.behaviorSubject("concat")
+
+firstPublisher.concat(nextPublisher).subscribe(...) { println(it) }
+
+firstPublisher.value = "love"
+firstPublisher.complete()
+
+```
+Output will be "i" then "love" then "concat".
+
 #### WithPreviousValue
 Transform the new value in a oldValue -> newValue pair
 ```kotlin

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.streams.reactive
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchQueue
+import com.mirego.trikot.streams.reactive.processors.ConcatProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
@@ -83,4 +84,16 @@ fun <T> Publisher<T>.distinctUntilChanged(): Publisher<T> {
 
 fun <T> Publisher<T>.withPreviousValue(): Publisher<Pair<T?, T>> {
     return WithPreviousValueProcessor(this)
+}
+
+fun <T> Publisher<T>.concat(publisher: Publisher<T>): Publisher<T> {
+    return ConcatProcessor(this, publisher)
+}
+
+fun <T> Publisher<T>.startWith(value: T): Publisher<T> {
+    return ConcatProcessor(value.just(), this)
+}
+
+fun <T, R> Publisher<T>.filterNotNull(block: ((T) -> R?)): Publisher<R> {
+    return this.filter { block(it) != null }.map { block(it)!! }
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ConcatProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ConcatProcessor.kt
@@ -1,0 +1,39 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
+import com.mirego.trikot.streams.reactive.subscribe
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+class ConcatProcessor<T>(parentPublisher: Publisher<T>, private val nextPublisher: Publisher<T>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return ConcatProcessorSubscription(subscriber, nextPublisher)
+    }
+
+    class ConcatProcessorSubscription<T>(
+        private val subscriber: Subscriber<in T>,
+        private val nextPublisher: Publisher<T>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+        private val cancellableManagerProvider = CancellableManagerProvider()
+
+        override fun onCancel(s: Subscription) {
+            super.onCancel(s)
+            cancellableManagerProvider.cancel()
+        }
+
+        override fun onComplete() {
+            nextPublisher.subscribe(cancellableManagerProvider.cancelPreviousAndCreate(),
+                onNext = { subscriber.onNext(it) },
+                onError = { subscriber.onError(it) },
+                onCompleted = { subscriber.onComplete() }
+            )
+        }
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            subscriber.onNext(t)
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublisherResultAccumulator.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublisherResultAccumulator.kt
@@ -1,0 +1,23 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.Cancellable
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import org.reactivestreams.Publisher
+
+class PublisherResultAccumulator<T>(publisher: Publisher<T>) : Cancellable {
+    val values = ArrayList<T>()
+    var error: Throwable? = null
+    var completed = false
+    val cancellableManager = CancellableManager()
+
+    init {
+        publisher.subscribe(cancellableManager,
+            onNext = { values.add(it) },
+            onError = { error = it },
+            onCompleted = { completed = true })
+    }
+
+    override fun cancel() {
+        cancellableManager.cancel()
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
@@ -1,0 +1,30 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import org.reactivestreams.Publisher
+
+fun <T> Publisher<T>.get(block: (T) -> Unit) {
+    subscribe(CancellableManager(), onNext = block)
+}
+
+fun <T> Publisher<T>.getOnce(block: (T) -> Unit) {
+    first().get(block)
+}
+
+fun <T> Publisher<T>.assertEquals(expectedValue: T?) {
+    var value: T? = null
+    get { value = it }
+    kotlin.test.assertEquals(expectedValue, value)
+}
+
+fun <T> Publisher<T>.assertTrue(block: (T?) -> Boolean) {
+    var value: T? = null
+    get { value = it }
+    kotlin.test.assertTrue { block(value) }
+}
+
+fun <T> Publisher<T>.assertCompleted() {
+    var completed = false
+    subscribe(CancellableManager(), onNext = {}, onError = {}, onCompleted = { completed = true })
+    assertTrue { completed }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ConcatProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ConcatProcessorTests.kt
@@ -1,0 +1,91 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.reactive.BehaviorSubject
+import com.mirego.trikot.streams.reactive.PublisherResultAccumulator
+import com.mirego.trikot.streams.reactive.Publishers
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConcatProcessorTests {
+    lateinit var firstPublisher: BehaviorSubject<String>
+    lateinit var secondPublisher: BehaviorSubject<String>
+    lateinit var processor: ConcatProcessor<String>
+    lateinit var accumulator: PublisherResultAccumulator<String>
+
+    @BeforeTest
+    fun setup() {
+        firstPublisher = Publishers.behaviorSubject()
+        secondPublisher = Publishers.behaviorSubject()
+        processor = ConcatProcessor(firstPublisher, secondPublisher)
+        accumulator = PublisherResultAccumulator(processor)
+    }
+
+    @Test
+    fun noValueAreDispatchedFromSecondObservableWhenFirstAsNotCompleted() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        firstPublisher.value = "b"
+        assertEquals(listOf("a", "b"), accumulator.values)
+        assertEquals(false, accumulator.completed)
+        assertEquals(null, accumulator.error)
+    }
+
+    @Test
+    fun valuesFromSecondPublisherAreDispatchedAfterFirstPublisherCompleted() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        firstPublisher.value = "b"
+        firstPublisher.complete()
+        assertEquals(listOf("a", "b", "1"), accumulator.values)
+        assertEquals(false, accumulator.completed)
+        assertEquals(null, accumulator.error)
+    }
+
+    @Test
+    fun valuesFromSecondPublisherAreBufferedUntilFirstPublisherCompleted() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        secondPublisher.value = "2"
+        firstPublisher.value = "b"
+        firstPublisher.complete()
+        assertEquals(listOf("a", "b", "2"), accumulator.values)
+        assertEquals(false, accumulator.completed)
+        assertEquals(null, accumulator.error)
+    }
+
+    @Test
+    fun completedWhenBothPublisherAreCompleted() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        secondPublisher.complete()
+        firstPublisher.value = "b"
+        firstPublisher.complete()
+        assertEquals(listOf("a", "b", "1"), accumulator.values)
+        assertEquals(true, accumulator.completed)
+        assertEquals(null, accumulator.error)
+    }
+
+    @Test
+    fun dispatchErrorsFromTheFirstSubscriber() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        firstPublisher.value = "b"
+        firstPublisher.error = Throwable()
+        assertEquals(listOf("a", "b"), accumulator.values)
+        assertEquals(false, accumulator.completed)
+        assertEquals(firstPublisher.error, accumulator.error)
+    }
+
+    @Test
+    fun dispatchAllValuesFromTheFirstPublisherBeforeDispatchingTheErrorFromTheSecondPublisher() {
+        firstPublisher.value = "a"
+        secondPublisher.value = "1"
+        secondPublisher.error = Throwable()
+        firstPublisher.value = "b"
+        firstPublisher.complete()
+        assertEquals(listOf("a", "b"), accumulator.values)
+        assertEquals(false, accumulator.completed)
+        assertEquals(secondPublisher.error, accumulator.error)
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/WithPreviousValueProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/WithPreviousValueProcessorTests.kt
@@ -1,42 +1,24 @@
 package com.mirego.trikot.streams.reactive.processors
 
-import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.PublisherResultAccumulator
 import com.mirego.trikot.streams.reactive.Publishers
-import com.mirego.trikot.streams.reactive.subscribe
+import com.mirego.trikot.streams.reactive.asPublisher
+import com.mirego.trikot.streams.reactive.assertEquals
 import com.mirego.trikot.streams.reactive.withPreviousValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class WithPreviousValueProcessorTests {
     @Test
     fun withoutPreviousValue() {
-        val publisher = Publishers.behaviorSubject("a")
-        var previousValue: String? = null
-        var actualValue: String? = null
-
-        publisher.withPreviousValue().subscribe(CancellableManager()) {
-            previousValue = it.first
-            actualValue = it.second
-        }
-
-        assertNull(previousValue)
-        assertEquals("a", actualValue)
+        "a".asPublisher().withPreviousValue().assertEquals(Pair(null, "a"))
     }
 
     @Test
     fun withPreviousValue() {
         val publisher = Publishers.behaviorSubject("a")
-        var previousValue: String? = null
-        var actualValue: String? = null
-
-        publisher.withPreviousValue().subscribe(CancellableManager()) {
-            previousValue = it.first
-            actualValue = it.second
-        }
+        val accumulator = PublisherResultAccumulator(publisher.withPreviousValue())
         publisher.value = "b"
-
-        assertEquals("a", previousValue)
-        assertEquals("b", actualValue)
+        assertEquals(listOf(Pair(null, "a"), Pair("a", "b")), accumulator.values)
     }
 }


### PR DESCRIPTION
## Description
Add `Concat` processor (also `StartWith` extension function)

Add many tests helpers to validate subscriptions.

## How Has This Been Tested?
See added tests 

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
