### PR TITLE
Ensure CancellableManager.cancelAll() is sequential

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
@@ -2,8 +2,11 @@ package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import com.mirego.trikot.foundation.concurrent.freeze
 
 class CancellableManager : Cancellable {
+    private val serialQueue = freeze(SynchronousSerialQueue())
     private val queueList = AtomicListReference<Cancellable>()
     private val isCancelled = AtomicReference(false)
 
@@ -30,10 +33,12 @@ class CancellableManager : Cancellable {
     }
 
     private fun doCancelAll() {
-        val value = queueList.value
-        queueList.removeAll(value)
-        for (cancellable in value) {
-            cancellable.cancel()
+        serialQueue.dispatchQueue.dispatch {
+            val value = queueList.value
+            queueList.removeAll(value)
+            for (cancellable in value) {
+                cancellable.cancel()
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Fix issue where `CancellableManager.cancelAll()` doesn't ensure that `cancellable.cancel()` is done sequentially.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)