### PR TITLE
Upgrade to kotlin 1.3.61, Gradle 5.6.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
-kotlin_version=1.3.60
-kotlin.native.version=1.3.60
-trikot_foundation_version=0.18.1
+kotlin_version=1.3.61
+trikot_foundation_version=0.25.1
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
@@ -3,10 +3,9 @@ package com.mirego.trikot.streams.cancellable
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
-import com.mirego.trikot.foundation.concurrent.freeze
 
 class CancellableManager : Cancellable {
-    private val serialQueue = freeze(SynchronousSerialQueue())
+    private val serialQueue = SynchronousSerialQueue()
     private val queueList = AtomicListReference<Cancellable>()
     private val isCancelled = AtomicReference(false)
 
@@ -33,7 +32,7 @@ class CancellableManager : Cancellable {
     }
 
     private fun doCancelAll() {
-        serialQueue.dispatchQueue.dispatch {
+        serialQueue.dispatch {
             val value = queueList.value
             queueList.removeAll(value)
             for (cancellable in value) {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -1,10 +1,10 @@
 package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
-import com.mirego.trikot.foundation.concurrent.MrFreeze
+import com.mirego.trikot.foundation.concurrent.freeze
 
 class CancellableManagerProvider : Cancellable {
-    private val cancellableManager = MrFreeze.freeze(CancellableManager())
+    private val cancellableManager = CancellableManager().also { freeze(it) }
     private val internalCancellableManagerRef =
         AtomicReference(CancellableManager())
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
@@ -3,7 +3,6 @@ package com.mirego.trikot.streams.reactive
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
-import com.mirego.trikot.foundation.concurrent.freeze
 import org.reactivestreams.Subscriber
 
 open class PublishSubjectImpl<T> : PublishSubject<T> {
@@ -11,8 +10,8 @@ open class PublishSubjectImpl<T> : PublishSubject<T> {
     private val atomicValue = AtomicReference<T?>(null)
     private val atomicError = AtomicReference<Throwable?>(null)
     private val isCompleted = AtomicReference(false)
-    private val serialQueue = freeze(SynchronousSerialQueue())
-    private val subscriptionQueue = SynchronousSerialQueue() // Not frozen because we do not want subscriber to impact performance on iOS with freezing time
+    private val serialQueue = SynchronousSerialQueue()
+    private val subscriptionQueue = SynchronousSerialQueue()
     protected val hasSubscriptions
         get() = subscriptions.value.count() > 0
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherSubscription.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherSubscription.kt
@@ -16,8 +16,9 @@ open class PublisherSubscription<T>(
     val isCancelled get() = privateIsCancelled.value
 
     override fun cancel() {
-        privateIsCancelled.setOrThrow(privateIsCancelled.value, true)
-        onCancel(this)
+        if (privateIsCancelled.compareAndSet(false, true)) {
+            onCancel(this)
+        }
     }
 
     fun dispatchValue(value: T) {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -3,7 +3,6 @@ package com.mirego.trikot.streams.reactive.processors
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
-import com.mirego.trikot.foundation.concurrent.freeze
 import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
 import com.mirego.trikot.streams.reactive.observeOn
 import com.mirego.trikot.streams.reactive.subscribe
@@ -29,7 +28,7 @@ class CombineLatestProcessor<T>(
         private val publishersResult = AtomicListReference<PublisherResult<T>>()
         private val hasSubscribed = AtomicReference(false)
         private val parentPublisherResultIndex = 0
-        private val serialQueue = freeze(SynchronousSerialQueue())
+        private val serialQueue = SynchronousSerialQueue()
 
         init {
             subscribeToCombinedPublishersIfNeeded()

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
@@ -2,7 +2,6 @@ package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
-import com.mirego.trikot.foundation.concurrent.freeze
 import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
 import com.mirego.trikot.streams.reactive.StreamsProcessorException
 import com.mirego.trikot.streams.reactive.observeOn
@@ -29,7 +28,7 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
         private val isChildCompleted = AtomicReference<Boolean>(false)
         private val currentPublisher = AtomicReference<Publisher<R>?>(null)
         private val onNextValidation = AtomicReference(0)
-        private val serialQueue = freeze(SynchronousSerialQueue())
+        private val serialQueue = SynchronousSerialQueue()
 
         override fun onCancel(s: Subscription) {
             super.onCancel(s)


### PR DESCRIPTION
## Description
- Remove useless freeze calls
- Fix cancellable manager serialQueue by dispatching to serialQueue instead of dispatchQueue
- Fix race condition where subscription might be cancelled at the same time we receive an error 

I will adjust foundation dependency when built

## Motivation and Context
While searching for memory issue in my app, I found both issues (in PublisherSubscription and CancellableManager).

## How Has This Been Tested?
- Directly in my application

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
