### PR TITLE
Do not uselessly freeze values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 kotlin_version=1.3.61
-trikot_foundation_version=0.25.1
+trikot_foundation_version=0.27.1
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -1,12 +1,10 @@
 package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
-import com.mirego.trikot.foundation.concurrent.freeze
 
 class CancellableManagerProvider : Cancellable {
-    private val cancellableManager = CancellableManager().also { freeze(it) }
-    private val internalCancellableManagerRef =
-        AtomicReference(CancellableManager())
+    private val cancellableManager = CancellableManager()
+    private val internalCancellableManagerRef = AtomicReference(CancellableManager())
 
     fun cancelPreviousAndCreate(): CancellableManager {
         internalCancellableManagerRef.value.cancel()

--- a/swift-extensions/TrikotPublisherExtensions.swift
+++ b/swift-extensions/TrikotPublisherExtensions.swift
@@ -34,15 +34,13 @@ extension NSObject {
 
     public func observe<V>(cancellableManager: CancellableManager, publisher: Publisher, toClosure closure: @escaping ((V) -> Void)) {
         PublisherExtensionsKt.subscribe(publisher, cancellableManager: cancellableManager) { (value: Any?) in
-            MrFreezeKt.freeze(objectToFreeze: value)
-            guard let typedValue = value as? V else {
-                print("Incorrect binding value type" + (value is NSNull ? " received NSNull, property should be marked as optional" : ""))
-                return
-            }
             if Thread.current.isMainThread {
+                assert(value is V, "Incorrect binding value type in \(self) - Cannot cast \(value.self) to \(V.self)")
                 closure(typedValue)
             } else {
+                MrFreezeKt.freeze(objectToFreeze: value)
                 DispatchQueue.main.async {
+                    assert(value is V, "Incorrect binding value type in \(self) - Cannot cast \(value.self) to \(V.self)")
                     closure(typedValue)
                 }
             }


### PR DESCRIPTION
## Description
- On iOS, only freeze the value if its not already on the main thread. If on the main thread, freezing will already be done.
- `CancellableManagerProvider` internal `CancellableManager` should not be frozen by default. It should only be frozen when `CancellableManagerProvider` is used on another thread (which means that all childs (including `CancellableManager`) will be frozen at that time.

## Motivation and Context
Do not freeze objets when always used on the main thread.

## How Has This Been Tested?
Manually stress testing this in 3 different applications

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
