### PR TITLE
First draft of Coroutines extensions

### DIFF
--- a/coroutines-extensions/build.gradle
+++ b/coroutines-extensions/build.gradle
@@ -1,0 +1,131 @@
+plugins {
+    id 'kotlin-multiplatform'
+    id 'org.jlleitschuh.gradle.ktlint'
+    id 'mirego.release' version '1.13'
+    id 'mirego.publish' version '1.0'
+}
+
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
+    maven { url "https://kotlin.bintray.com/kotlinx" }
+    maven { url 'https://jitpack.io' }
+    maven { url('https://s3.amazonaws.com/mirego-maven/public') }
+}
+
+group 'com.mirego.trikot'
+
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm')
+        fromPreset(presets.js, 'js')
+        fromPreset(presets.iosArm32, 'iosArm32')
+        fromPreset(presets.iosArm64, 'iosArm64')
+        fromPreset(presets.iosX64, 'iosX64')
+        fromPreset(presets.tvosArm64, 'tvosArm64')
+        fromPreset(presets.tvosX64, 'tvosX64')
+    }
+    sourceSets {
+        all {
+            languageSettings {
+                useExperimentalAnnotation('kotlin.Experimental')
+            }
+        }
+
+        commonMain {
+            dependencies {
+                implementation "com.mirego.trikot:foundation:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams:$streams_version"
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$kotlin_coroutines_version"
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-test-common'
+                implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
+            }
+        }
+        jvmMain {
+            dependencies {
+                implementation "com.mirego.trikot:foundation-jvm:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-jvm:$streams_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+            }
+        }
+        jvmTest {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-test'
+                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+            }
+        }
+        jsMain {
+            dependencies {
+                implementation "com.mirego.trikot:foundation-js:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-js:$streams_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlin_coroutines_version"
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
+            }
+        }
+
+        nativeMain {
+            dependsOn(commonMain)
+            dependencies {
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$kotlin_coroutines_version"
+            }
+        }
+
+        iosArm32Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:foundation-iosarm32:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-iosarm32:$streams_version"
+            }
+        }
+
+        iosArm64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:foundation-iosarm64:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-iosarm64:$streams_version"
+            }
+        }
+
+        iosX64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:foundation-iosx64:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-iosx64:$streams_version"
+            }
+        }
+        tvosArm64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:foundation-tvosarm64:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-tvosarm64:$streams_version"
+            }
+        }
+
+        tvosX64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:foundation-tvosx64:$trikot_foundation_version"
+                implementation "com.mirego.trikot:streams-tvosx64:$streams_version"
+            }
+        }
+    }
+}
+
+release {
+   checkTasks = ['check']
+   buildTasks = ['publish']
+   updateVersionPart = 1
+}
+
+// workaround for https://youtrack.jetbrains.com/issue/KT-27170
+configurations {
+    compileClasspath
+}

--- a/coroutines-extensions/gradle.properties
+++ b/coroutines-extensions/gradle.properties
@@ -1,0 +1,4 @@
+#Tue Jan 07 16:10:17 EST 2020
+version=0.54.1-SNAPSHOT
+streams_version=0.53.1
+

--- a/coroutines-extensions/src/commonMain/kotlin/com/mirego/trikot/streams/flow/ReactiveFlow.kt
+++ b/coroutines-extensions/src/commonMain/kotlin/com/mirego/trikot/streams/flow/ReactiveFlow.kt
@@ -1,0 +1,222 @@
+package com.mirego.trikot.streams.flow
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import kotlinx.coroutines.AbstractCoroutine
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.internal.ChannelFlow
+import kotlinx.coroutines.flow.internal.SendingCollector
+import kotlinx.coroutines.handleCoroutineException
+import kotlinx.coroutines.intrinsics.startCoroutineCancellable
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Transforms the given flow to a reactive specification compliant [Publisher].
+ *
+ * This function is integrated with `ReactorContext` from `kotlinx-coroutines-reactor` module,
+ * see its documentation for additional details.
+ */
+fun <T : Any> Flow<T>.asFlowPublisher(): Publisher<T> = FlowAsPublisher(this)
+
+/**
+ * Transforms the given reactive [Publisher] into [Flow].
+ * Use [buffer] operator on the resulting flow to specify the size of the backpressure.
+ * More precisely, it specifies the value of the subscription's [request][Subscription.request].
+ * `1` is used by default.
+ *
+ * If any of the resulting flow transformations fails, subscription is immediately cancelled and all in-flights elements
+ * are discarded.
+ *
+ * This function is integrated with `ReactorContext` from `kotlinx-coroutines-reactor` module,
+ * see its documentation for additional details.
+ */
+fun <T : Any> Publisher<T>.asFlow(): Flow<T> = PublisherAsFlow(this, 1)
+
+/**
+ * Adapter that transforms [Flow] into TCK-complaint [Publisher].
+ * [cancel] invocation cancels the original flow.
+ */
+private class FlowAsPublisher<T : Any>(private val flow: Flow<T>) : Publisher<T> {
+    override fun subscribe(s: Subscriber<in T>) {
+        val subscription = FlowSubscription(flow, s)
+        s.onSubscribe(subscription)
+        subscription.request(Long.MAX_VALUE)
+    }
+}
+
+@UseExperimental(InternalCoroutinesApi::class)
+class FlowSubscription<T>(
+    val flow: Flow<T>,
+    val subscriber: Subscriber<in T>
+) : Subscription, AbstractCoroutine<Unit>(Dispatchers.Unconfined, false) {
+    private val requested = AtomicReference(0L)
+    private val producer = AtomicReference<CancellableContinuation<Unit>?>(null)
+
+    override fun onStart() {
+        ::flowProcessing.startCoroutineCancellable(this)
+    }
+
+    private suspend fun flowProcessing() {
+        try {
+            consumeFlow()
+            subscriber.onComplete()
+        } catch (e: Throwable) {
+            try {
+                if (e is CancellationException) {
+                    subscriber.onComplete()
+                } else {
+                    subscriber.onError(e)
+                }
+            } catch (e: Throwable) {
+                // Last ditch report
+                handleCoroutineException(coroutineContext, e)
+            }
+        }
+    }
+
+    /*
+     * This method has at most one caller at any time (triggered from the `request` method)
+     */
+    private suspend fun consumeFlow() {
+        flow.collect { value ->
+            /*
+             * Flow is scopeless, thus if it's not active, its subscription was cancelled.
+             * No intermediate "child failed, but flow coroutine is not" states are allowed.
+             */
+            coroutineContext.ensureActive()
+            if (requested.value <= 0L) {
+                suspendCancellableCoroutine<Unit> {
+                    producer.setOrThrow(producer.value, it)
+                    if (requested.value != 0L) it.resumeSafely()
+                }
+            }
+            requested.value.also {
+                requested.setOrThrow(requested.value, it - 1L)
+            }
+
+            subscriber.onNext(value)
+        }
+    }
+
+    override fun cancel() {
+        cancel(null)
+    }
+
+    override fun request(n: Long) {
+        if (n <= 0) {
+            return
+        }
+        start()
+        requested.value.also { value ->
+            val newValue = value + n
+            requested.setOrThrow(value, if (newValue <= 0L) Long.MAX_VALUE else newValue)
+        }
+        producer.value.also { currentProducer ->
+            producer.setOrThrow(currentProducer, null)
+            currentProducer?.resumeSafely()
+        }
+    }
+
+    private fun CancellableContinuation<Unit>.resumeSafely() {
+        val token = tryResume(Unit)
+        if (token != null) {
+            completeResume(token)
+        }
+    }
+}
+
+@UseExperimental(InternalCoroutinesApi::class)
+private class PublisherAsFlow<T : Any>(
+    private val publisher: Publisher<T>,
+    capacity: Int
+) : ChannelFlow<T>(EmptyCoroutineContext, capacity) {
+    override fun create(context: CoroutineContext, capacity: Int): ChannelFlow<T> =
+        PublisherAsFlow(publisher, capacity)
+
+    override fun produceImpl(scope: CoroutineScope): ReceiveChannel<T> {
+        TODO("Not implemented")
+    }
+
+    private val requestSize: Long
+        get() = when (capacity) {
+            Channel.CONFLATED -> Long.MAX_VALUE // request all and conflate incoming
+            Channel.RENDEZVOUS -> 1L // need to request at least one anyway
+            Channel.UNLIMITED -> Long.MAX_VALUE // reactive streams way to say "give all" must be Long.MAX_VALUE
+            else -> capacity.toLong().also { check(it >= 1) }
+        }
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        val subscriber = ReactiveSubscriber<T>(capacity, requestSize)
+        publisher.subscribe(subscriber)
+        try {
+            var consumed = 0L
+            while (true) {
+                val value = subscriber.takeNextOrNull() ?: break
+                collector.emit(value)
+                if (++consumed == requestSize) {
+                    consumed = 0L
+                    subscriber.makeRequest()
+                }
+            }
+        } finally {
+            subscriber.cancel()
+        }
+    }
+
+    // The second channel here is used only for broadcast
+    override suspend fun collectTo(scope: ProducerScope<T>) =
+        collect(SendingCollector(scope.channel))
+}
+
+@Suppress("SubscriberImplementation")
+@UseExperimental(InternalCoroutinesApi::class)
+private class ReactiveSubscriber<T : Any>(
+    capacity: Int,
+    private val requestSize: Long
+) : Subscriber<T> {
+    private lateinit var subscription: Subscription
+    private val channel = Channel<T>(capacity)
+
+    suspend fun takeNextOrNull(): T? = channel.receiveOrClosed().valueOrNull
+
+    override fun onNext(value: T) {
+        // Controlled by requestSize
+        require(channel.offer(value)) { "Element $value was not added to channel because it was full, $channel" }
+    }
+
+    override fun onComplete() {
+        channel.close()
+    }
+
+    override fun onError(t: Throwable) {
+        channel.close(t)
+    }
+
+    override fun onSubscribe(s: Subscription) {
+        subscription = s
+        makeRequest()
+    }
+
+    fun makeRequest() {
+        subscription.request(requestSize)
+    }
+
+    fun cancel() {
+        subscription.cancel()
+    }
+}

--- a/coroutines-extensions/src/jvmTest/kotlin/com/mirego/trikot/streams/flow/AsFlowPublisherTests.kt
+++ b/coroutines-extensions/src/jvmTest/kotlin/com/mirego/trikot/streams/flow/AsFlowPublisherTests.kt
@@ -1,0 +1,97 @@
+package com.mirego.trikot.streams.flow
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runBlockingTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class AsFlowPublisherTests {
+    @Test
+    fun simpleasFlowPublisherTest() = runBlockingTest {
+        val flowMock = flowMock()
+        val publisher = flowMock.asFlowPublisher()
+
+        val values = ArrayList<Int>()
+        var isCompleted = false
+        var error: Throwable? = null
+        publisher.subscribe(CancellableManager(),
+            onNext = { values.add(it) },
+            onError = { error = it },
+            onCompleted = { isCompleted = true }
+        )
+        assertEquals(listOf(0, 1), values)
+        assertTrue { isCompleted }
+        assertNull(error)
+    }
+
+    @Test
+    fun erroredFlowPublisherTest() = runBlockingTest {
+        val exception = IllegalStateException()
+        val flowMock = flowWithException(exception)
+        val publisher = flowMock.asFlowPublisher()
+
+        val values = ArrayList<Int>()
+        var isCompleted = false
+        var error: Throwable? = null
+        publisher.subscribe(CancellableManager(),
+            onNext = { values.add(it) },
+            onError = { error = it },
+            onCompleted = { isCompleted = true }
+        )
+        assertEquals(listOf(0, 1), values)
+        assertFalse { isCompleted }
+        assertEquals(exception, error)
+    }
+
+    @Test
+    fun cancelledFlowPublisherTest() = runBlockingTest {
+        var exception: Exception? = null
+        val flowMock = flowWithDelay(1000) { exception = it }
+        val publisher = flowMock.asFlowPublisher()
+
+        val values = ArrayList<Int>()
+        var isCompleted = false
+        var error: Throwable? = null
+        val cancellableManager = CancellableManager()
+        publisher.subscribe(cancellableManager,
+            onNext = { values.add(it) },
+            onError = { error = it },
+            onCompleted = { isCompleted = true }
+        )
+        cancellableManager.cancel()
+        assertTrue { exception is CancellationException }
+        assertEquals(emptyList<Int>(), values)
+        assertFalse { isCompleted }
+        assertNull(error)
+    }
+
+    private fun flowMock(): Flow<Int> = flow {
+        emit(0)
+        emit(1)
+    }
+
+    private fun flowWithException(exception: IllegalStateException): Flow<Int> = flow {
+        emit(0)
+        emit(1)
+        throw exception
+    }
+
+    private fun flowWithDelay(delayMs: Long = 1000, callback: (Exception) -> Unit): Flow<Int> = flow {
+        try {
+            delay(delayMs)
+            emit(0)
+            emit(1)
+        } catch (e: CancellationException) {
+            callback(e)
+        }
+    }
+}

--- a/coroutines-extensions/src/jvmTest/kotlin/com/mirego/trikot/streams/flow/AsFlowTests.kt
+++ b/coroutines-extensions/src/jvmTest/kotlin/com/mirego/trikot/streams/flow/AsFlowTests.kt
@@ -1,0 +1,78 @@
+package com.mirego.trikot.streams.flow
+
+import com.mirego.trikot.streams.reactive.Publishers
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class AsFlowTests {
+    @Test
+    fun behaviorAsFlowTest() = runBlockingTest {
+        val publisher = Publishers.behaviorSubject(0)
+        val flow = publisher.asFlow()
+        val values = ArrayList<Int>()
+        val job = launch {
+            flow.collect {
+                values.add(it)
+            }
+        }
+        publisher.value = 1
+        job.cancel()
+
+        assertEquals(listOf(0, 1), values)
+    }
+
+    @Test
+    fun publishAsFlowTest() = runBlockingTest {
+        val publisher = Publishers.publishSubject<Int>()
+        val flow = publisher.asFlow()
+        val values = ArrayList<Int>()
+        val job = launch {
+            flow.collect {
+                values.add(it)
+            }
+        }
+        publisher.value = 1
+
+        assertEquals(listOf(1), values)
+        assertFalse { job.isCompleted }
+
+        job.cancel()
+    }
+
+    @Test
+    fun errorFlowTest() = runBlockingTest {
+        val expectedError = IllegalStateException()
+        val publisher = Publishers.publishSubject<Int>()
+        val flow = publisher.asFlow()
+        val values = ArrayList<Int>()
+        val job = launch {
+            flow.collect {
+                values.add(it)
+            }
+        }
+        publisher.error = expectedError
+
+        assertTrue { job.isCompleted }
+    }
+
+    @Test
+    fun completionFlowTest() = runBlockingTest {
+        val publisher = Publishers.publishSubject<Int>()
+        val flow = publisher.asFlow()
+        val values = ArrayList<Int>()
+        val job = launch {
+            flow.collect {
+                values.add(it)
+            }
+        }
+        publisher.complete()
+
+        assertTrue { job.isCompleted }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.3.61
 trikot_foundation_version=0.27.1
+kotlin_coroutines_version=1.3.3
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/jenkins-jobs/plugin_release.groovy
+++ b/jenkins-jobs/plugin_release.groovy
@@ -32,7 +32,7 @@ job("$context.jobFullName-streams") {
         gradle {
             useWrapper()
             makeExecutable()
-            tasks(':streams:release')
+            tasks(':streams:release :coroutines-extensions:release')
             switches('-i -s')
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,4 +24,4 @@ pluginManagement {
 rootProject.name = 'trikot.streams'
 enableFeaturePreview("GRADLE_METADATA")
 
-include ':streams', ':android-ktx'
+include ':streams', ':coroutines-extensions', ':android-ktx'

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MapProcessorTests.kt
@@ -38,11 +38,12 @@ class MapProcessorTests {
     @Test
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
-        var receivedException: StreamsProcessorException? = null
 
         assertFailsWith(IllegalStateException::class) {
-            publisher.map { throw IllegalStateException() }.subscribe(CancellableManager(), onNext = {
-            }, onError = { receivedException = it as StreamsProcessorException })
+            publisher.map { throw IllegalStateException() }.subscribe(CancellableManager(),
+                onNext = {},
+                onError = {}
+            )
         }
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
@@ -95,11 +95,12 @@ class SwitchMapProcessorTests {
     @Test
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
-        var receivedException: StreamsProcessorException? = null
 
         assertFailsWith(IllegalStateException::class) {
-            publisher.switchMap<String, String> { throw IllegalStateException() }.subscribe(CancellableManager(), onNext = {
-            }, onError = { receivedException = it as StreamsProcessorException })
+            publisher.switchMap<String, String> { throw IllegalStateException() }.subscribe(CancellableManager(),
+                onNext = {},
+                onError = {}
+            )
         }
     }
 


### PR DESCRIPTION
## Description
This pull request is a draft of multiplatform port of ReactiveStreams utils of Kotlinx.Coroutines to convert `Flow<T>` -> `Publisher<T>` and `Publisher<T>` -> `Flow<T>`

## Motivation and Context
As Native Coroutines becomes more and more a near outcome, we need to be able to migrate our existing applications to coroutines. To do so, we create adapters that will be able to migrate our publishers to Flow and vice versa.

We do not support CoroutinesContext for now. This will need to be completed in another PR.

** This is not ready for production yet **

## How Has This Been Tested?
- See attached tests
- It was not battle tested in real use case scenario

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
