### PR TITLE
Include @JsName to have constant naming in JavaScript

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -3,22 +3,27 @@ package com.mirego.trikot.streams.reactive
 import org.reactivestreams.Publisher
 
 object Publishers {
+    @JsName("behaviorSubject")
     fun <T> behaviorSubject(value: T? = null): BehaviorSubject<T> {
         return BehaviorSubjectImpl(value)
     }
 
+    @JsName("publishSubject")
     fun <T> publishSubject(): PublishSubject<T> {
         return PublishSubjectImpl()
     }
 
+    @JsName("just")
     fun <T> just(value: T): Publisher<T> {
         return behaviorSubject(value).also { it.complete() }
     }
 
+    @JsName("empty")
     fun <T> empty(): Publisher<T> {
         return PublishSubjectImpl()
     }
 
+    @JsName("completed")
     fun <T> completed(): Publisher<T> {
         return PublishSubjectImpl<T>().also { it.complete() }
     }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.streams.reactive
 
 import org.reactivestreams.Publisher
+import kotlin.js.JsName
 
 object Publishers {
     @JsName("behaviorSubject")

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Publisher.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Publisher.kt
@@ -1,5 +1,7 @@
 package org.reactivestreams
 
+import kotlin.js.JsName
+
 /**
  * A [Publisher] is a provider of a potentially unbounded number of sequenced elements, publishing them according to
  * the demand received from its [Subscriber](s).

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Publisher.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Publisher.kt
@@ -30,5 +30,6 @@ interface Publisher<T> {
      *
      * @param s the [Subscriber] that will consume signals from this [Publisher]
      */
+    @JsName("subscribe")
     fun subscribe(s: Subscriber<in T>)
 }

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Subscriber.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Subscriber.kt
@@ -34,6 +34,7 @@ interface Subscriber<T> {
      * @param s
      * [Subscription] that allows requesting data via [Subscription.request]
      */
+    @JsName("onSubscribe")
     fun onSubscribe(s: Subscription)
 
     /**
@@ -41,6 +42,7 @@ interface Subscriber<T> {
      *
      * @param t the element signaled
      */
+    @JsName("onNext")
     fun onNext(t: T)
 
     /**
@@ -51,6 +53,7 @@ interface Subscriber<T> {
      *
      * @param t the throwable signaled
      */
+    @JsName("onError")
     fun onError(t: Throwable)
 
     /**
@@ -59,5 +62,6 @@ interface Subscriber<T> {
      *
      * No further events will be sent even if [Subscription.request] is invoked again.
      */
+    @JsName("onComplete")
     fun onComplete()
 }

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Subscriber.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Subscriber.kt
@@ -1,5 +1,7 @@
 package org.reactivestreams
 
+import kotlin.js.JsName
+
 /**
  * Will receive call to [.onSubscribe] once after passing an instance of [Subscriber] to [Publisher.subscribe].
  *

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Subscription.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Subscription.kt
@@ -17,6 +17,7 @@ interface Subscription {
      *
      * @param n the strictly positive number of elements to requests to the upstream [Publisher]
      */
+    @JsName("request")
     fun request(n: Long)
 
     /**
@@ -25,5 +26,6 @@ interface Subscription {
      *
      * Data may still be sent to meet previously signalled demand after calling cancel.
      */
+    @JsName("cancel")
     fun cancel()
 }

--- a/streams/src/commonMain/kotlin/org/reactivestreams/Subscription.kt
+++ b/streams/src/commonMain/kotlin/org/reactivestreams/Subscription.kt
@@ -1,5 +1,7 @@
 package org.reactivestreams
 
+import kotlin.js.JsName
+
 interface Subscription {
     /**
      * No events will be sent by a [Publisher] until demand is signaled via this method.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Include `@JsName` to methods used on the web platform.

## Motivation and Context

Without these decorators, methods are exposed with an inconsistant naming, like `.onNext_11rb$()` instead of `.onNext()`.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
