### PR TITLE
Introducing better error flow management

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -30,7 +30,8 @@ class CombineLatestProcessor<T>(
         private val parentPublisherResultIndex = 0
         private val serialQueue = SynchronousSerialQueue()
 
-        init {
+        override fun onSubscribe(s: Subscription) {
+            super.onSubscribe(s)
             subscribeToCombinedPublishersIfNeeded()
         }
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorReturnProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorReturnProcessor.kt
@@ -22,6 +22,7 @@ class OnErrorReturnProcessor<T>(parentPublisher: Publisher<T>, private val block
         }
 
         override fun onError(t: Throwable) {
+            cancelActiveSubscription()
             subscriber.onNext(block(t))
         }
     }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
@@ -22,17 +22,20 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : BehaviorSu
 
     override fun onNoSubscription() {
         super.onNoSubscription()
+        cancellableManagerProvider.cancelPreviousAndCreate()
         if (!completed) {
             cleanupValues()
         }
-        cancellableManagerProvider.cancelPreviousAndCreate()
     }
 
     override fun onSubscribe(s: Subscription) = with(subscriptionCancellableManager.value) { add { s.cancel() } }
 
     override fun onNext(t: T) = let { value = t }
 
-    override fun onError(t: Throwable) = let { error = t }
+    override fun onError(t: Throwable) = let {
+        cancellableManagerProvider.cancelPreviousAndCreate()
+        error = t
+    }
 
     override fun onComplete() {
         cancellableManagerProvider.cancelPreviousAndCreate()

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/ColdPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/ColdPublisherTests.kt
@@ -9,10 +9,10 @@ class ColdPublisherTests {
     @Test
     fun blockIsExecutedOnSubscription() {
         var executed = false
-        val coldPublisher = ColdPublisher<String>({
+        val coldPublisher = ColdPublisher<String> {
             executed = true
             Publishers.behaviorSubject()
-        })
+        }
         coldPublisher.subscribe(CancellableManager()) {}
         assertTrue { executed }
     }
@@ -21,11 +21,11 @@ class ColdPublisherTests {
     fun cancelledOnUnsubscription() {
         var executed = false
         var cancelled = false
-        val coldPublisher = ColdPublisher<String>({
+        val coldPublisher = ColdPublisher<String> {
             executed = true
             it.add { cancelled = true }
             Publishers.behaviorSubject()
-        })
+        }
         val subscription = CancellableManager()
         coldPublisher.subscribe(subscription) {}
         subscription.cancel()
@@ -36,9 +36,9 @@ class ColdPublisherTests {
     @Test
     fun valueIsForwarded() {
         var publisher = Publishers.behaviorSubject<String>()
-        val coldPublisher = ColdPublisher<String>({
+        val coldPublisher = ColdPublisher {
             publisher
-        })
+        }
         var value: String? = null
         coldPublisher.subscribe(CancellableManager()) { value = it }
         publisher.value = "a"
@@ -49,10 +49,10 @@ class ColdPublisherTests {
     fun blockIsReexecutedIfResubscribed() {
         var executionCount = 0
 
-        val coldPublisher = ColdPublisher<String>({
+        val coldPublisher = ColdPublisher<String> {
             executionCount += 1
             Publishers.behaviorSubject()
-        })
+        }
 
         val cancellableManager = CancellableManager()
         coldPublisher.subscribe(cancellableManager) {}
@@ -66,10 +66,10 @@ class ColdPublisherTests {
     fun blockIsNotReexecutedIfResubscribedWhenCompleted() {
         var executionCount = 0
 
-        val coldPublisher = ColdPublisher({
+        val coldPublisher = ColdPublisher {
             executionCount += 1
             Publishers.behaviorSubject("value").also { it.complete() }
-        })
+        }
 
         val cancellableManager = CancellableManager()
         coldPublisher.subscribe(cancellableManager) {}
@@ -85,9 +85,9 @@ class ColdPublisherTests {
     fun errorIsForwarded() {
         val expectedError = Exception("Expected")
 
-        val coldPublisher = ColdPublisher<String>({
+        val coldPublisher = ColdPublisher {
             Publishers.behaviorSubject<String>().also { it.error = expectedError }
-        })
+        }
 
         val cancellableManager = CancellableManager()
         var receivedError: Throwable? = null
@@ -96,5 +96,25 @@ class ColdPublisherTests {
         }
 
         assertEquals(expectedError, receivedError)
+    }
+
+    @Test
+    fun valuesAreCleanedUp() {
+        val firstPublisher = Publishers.behaviorSubject("a").also { it.error = Throwable() }
+        val secondPublisher = Publishers.behaviorSubject("expectedValue")
+        var count = 0
+
+        val coldPublisher = ColdPublisher {
+            count++
+            val publisher = if (count == 1) firstPublisher else secondPublisher
+            publisher
+        }.shared()
+
+        coldPublisher.first().subscribe(CancellableManager()) {}
+
+        var receivedValue = "old"
+        coldPublisher.first().subscribe(CancellableManager()) { receivedValue = it }
+
+        assertEquals("expectedValue", receivedValue)
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
@@ -28,3 +28,7 @@ fun <T> Publisher<T>.assertCompleted() {
     subscribe(CancellableManager(), onNext = {}, onError = {}, onCompleted = { completed = true })
     assertTrue { completed }
 }
+
+class MockPublisher(initialValue: String? = null) : BehaviorSubjectImpl<String>(initialValue) {
+    val getHasSubscriptions get() = super.hasSubscriptions
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
@@ -1,7 +1,7 @@
 package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
-import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
+import com.mirego.trikot.streams.reactive.MockPublisher
 import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -145,7 +145,18 @@ class CombineLatestProcessorTests {
         assertEquals(1, callbackCount)
     }
 
-    class MockPublisher(initialValue: String? = null) : BehaviorSubjectImpl<String>(initialValue) {
-        val getHasSubscriptions get() = super.hasSubscriptions
+    @Test
+    fun onlyOneErrorIsDispatched() {
+        val firstPublisher = MockPublisher("a").also { it.error = Throwable() }
+        val secondPublisher = MockPublisher("b").also { it.error = Throwable() }
+        val thirdPublisher = MockPublisher("b").also { it.error = Throwable() }
+
+        var errorCount = 0
+        combine(listOf(firstPublisher, secondPublisher, thirdPublisher)).subscribe(CancellableManager(),
+            onNext = {},
+            onError = { errorCount ++ }
+        )
+
+        assertEquals(1, errorCount)
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorReturnProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorReturnProcessorTests.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.MockPublisher
 import com.mirego.trikot.streams.reactive.Publishers
 import com.mirego.trikot.streams.reactive.onErrorReturn
 import com.mirego.trikot.streams.reactive.subscribe
@@ -31,5 +32,14 @@ class OnErrorReturnProcessorTests {
         assertEquals(expectedError, receivedError)
         assertEquals(expectedValue, receivedValue)
         assertFalse("Should not be completed") { isCompleted }
+    }
+
+    @Test
+    fun parentIsUnsubscribedOnError() {
+        val parentPublisher = MockPublisher().also { it.error = Throwable() }
+        parentPublisher.onErrorReturn { "a" }.subscribe(CancellableManager()) {
+        }
+
+        assertFalse(parentPublisher.getHasSubscriptions)
     }
 }


### PR DESCRIPTION
## Description
**ColdPublisher**
- Remove initial value -> Prefer `ColdPublisher {}.startWith()`
- Clean values when there is no more subscribers if not completed (Like the shared processor)

**PublishSubject**
- Use a single queue for subscriptions and values
- Use the queue for dispatching completed (A race condition could happen where the completed was processed before the value)

**CombineLatest**
- Subscribe to combined publisher when after subscribing to the master publisher

**SharedProcessor** and **SwitchMapProcessor** and **OnErrorReturnProcessor**
- Unsubscribe from parent publisher when receiving an error (As all subscriber are supposed to do)

## Motivation and Context
In the application I am working on, I ran into a case where an error was assigned twice to a SharedProcessor. I had to track this bug and understand how it can happen. While tracking this bug, I found many issues where publishers were keeping their subscription active after an error. When intensively used with combining and SwitchMapping, Some publishers were receiving twice an error instead of only once.

## How Has This Been Tested?
See attached test.
Ran this on a heavily reactive application ;)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
