### PR TITLE
Make sure Empty publisher completes and add Never publisher

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -14,24 +14,46 @@ object Publishers {
         return PublishSubjectImpl()
     }
 
+    /**
+     * Create a Publisher that emits a particular item
+     * @see <a href="http://reactivex.io/documentation/operators/just.html">http://reactivex.io/documentation/operators/just.html</a>
+     */
     @JsName("just")
     fun <T> just(value: T): Publisher<T> {
         return behaviorSubject(value).also { it.complete() }
     }
 
+    /**
+     * Create a Publisher that emits no items but terminates normally
+     * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
+     */
     @JsName("empty")
     fun <T> empty(): Publisher<T> {
-        return PublishSubjectImpl()
+        return publishSubject<T>().also { it.complete() }
     }
 
+    /**
+     * Create a Publisher that emits no items and does not terminate
+     * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
+     */
+    @JsName("never")
+    fun <T> never(): Publisher<T> {
+        return publishSubject()
+    }
+
+    /**
+     * Create a Publisher that emits no items and terminates with an error
+     * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
+     */
+    @JsName("error")
+    fun <T> error(throwable: Throwable): Publisher<T> {
+        return behaviorSubject<T>().also { it.error = throwable }
+    }
+
+    @Deprecated("Use empty() instead", ReplaceWith("Publishers.empty<T>()"))
     @JsName("completed")
     fun <T> completed(): Publisher<T> {
-        return PublishSubjectImpl<T>().also { it.complete() }
-    }
-
-    @JsName("error")
-    fun <T> error(error: Throwable): Publisher<T> {
-        return behaviorSubject<T>().also { it.error = error }
+        return publishSubject<T>().also { it.complete() }
     }
 }
 

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTestUtils.kt
@@ -29,6 +29,22 @@ fun <T> Publisher<T>.assertCompleted() {
     assertTrue { completed }
 }
 
+fun <T> Publisher<T>.verify(value: T?, error: Throwable?, completed: Boolean) {
+    var actualValue: T? = null
+    var actualError: Throwable? = null
+    var actualCompleted = false
+
+    subscribe(CancellableManager(),
+        onNext = { actualValue = it },
+        onError = { actualError = it },
+        onCompleted = { actualCompleted = true }
+    )
+
+    kotlin.test.assertEquals(value, actualValue)
+    kotlin.test.assertEquals(error, actualError)
+    kotlin.test.assertEquals(completed, actualCompleted)
+}
+
 class MockPublisher(initialValue: String? = null) : BehaviorSubjectImpl<String>(initialValue) {
     val getHasSubscriptions get() = super.hasSubscriptions
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/PublishersTests.kt
@@ -1,0 +1,46 @@
+package com.mirego.trikot.streams.reactive
+
+import kotlin.test.Test
+
+class PublishersTests {
+
+    @Test
+    fun testJust() {
+        val value = 22
+
+        Publishers.just(value).verify(
+            value = value,
+            error = null,
+            completed = true
+        )
+    }
+
+    @Test
+    fun testEmpty() {
+        Publishers.empty<Int>().verify(
+            value = null,
+            error = null,
+            completed = true
+        )
+    }
+
+    @Test
+    fun testNever() {
+        Publishers.never<Int>().verify(
+            value = null,
+            error = null,
+            completed = false
+        )
+    }
+
+    @Test
+    fun testError() {
+        val throwable = Throwable()
+
+        Publishers.error<Int>(throwable).verify(
+            value = null,
+            error = throwable,
+            completed = false
+        )
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As stated in the [ReactiveX documentation](http://reactivex.io/documentation/operators/empty-never-throw.html), an "Empty" publisher should always complete to respect its contract.

The current `Publishers.empty<T>())` publisher is in fact a `Publishers.never<T>()` publisher, which was also introduced in this commit. This is thus a **breaking change** ⚠️ since usages of the "Empty" publisher will now receive a completion callback.

`Publishers.completed<T>()` has been deprecated in favor of `Publishers.empty<T>()` to better align with the [official ReactiveX naming](http://reactivex.io/documentation/operators.html#creating).

## Motivation and Context
<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes are introduced to be on par with the official ReativeX observables behaviour.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes are fully unit tested. 💯%

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ New feature (non-breaking change which adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
