### PR TITLE
Add finallyReturn to Promise

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
@@ -89,9 +89,14 @@ class Promise<T> internal constructor(
         onError = apply
     )
 
-    fun finally(execute: () -> Unit): Publisher<T> = thenReturn(
+    fun finally(execute: () -> Unit): Promise<T> = thenReturn(
         onSuccess = { execute(); resolve(it) },
         onError = { execute(); reject(it) }
+    )
+
+    fun <R> finallyReturn(supply: () -> Promise<R>): Promise<R> = thenReturn(
+        onSuccess = { supply() },
+        onError = { supply() }
     )
 
     fun then(onSuccess: (T) -> Unit, onError: (Throwable) -> Unit): Promise<T> = thenReturn(

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/promise/PromiseContinuationTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/promise/PromiseContinuationTests.kt
@@ -257,7 +257,7 @@ class PromiseContinuationTests {
     }
 
     @Test
-    fun finallyIsCalledOnSuccess() {
+    fun callingFinallyExecutesProvidedBlockOnSuccess() {
         var finallyCalled = false
 
         Promise.resolve(22)
@@ -267,12 +267,34 @@ class PromiseContinuationTests {
     }
 
     @Test
-    fun finallyIsCalledOnError() {
+    fun callingFinallyExecutesProvidedBlockOnError() {
         var finallyCalled = false
 
         Promise.reject<Int>(Throwable())
             .finally { finallyCalled = true }
 
         assertTrue(finallyCalled)
+    }
+
+    @Test
+    fun finallyReturnSuppliesNewPromiseOnSuccess() {
+        Promise.resolve(22)
+            .finallyReturn { Promise.resolve("Finally!") }
+            .verify(
+                value = "Finally!",
+                error = null,
+                completed = true
+            )
+    }
+
+    @Test
+    fun finallyReturnSuppliesNewPromiseOnError() {
+        Promise.reject<Int>(Throwable())
+            .finallyReturn { Promise.resolve("Finally!") }
+            .verify(
+                value = "Finally!",
+                error = null,
+                completed = true
+            )
     }
 }


### PR DESCRIPTION
## Description
Support returning a new Promise when the previous Promise is settled (wether fullfilled or rejected).

## Motivation and Context
This is usefull when chaining multiple promises sequentially. Such as 

```
logoutUseCase.logout()
    .finallyReturn { cleanupUseCase.cleanup() }
    .onError { analyticsUseCase.logCleanupFailed() }
    .finallyReturn { navigateToHome() }
```

## How Has This Been Tested?
💯% Unit tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
