### PR TITLE
Remove unused private code in AbstractProcessor

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/AbstractProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/AbstractProcessor.kt
@@ -1,6 +1,5 @@
 package com.mirego.trikot.streams.reactive.processors
 
-import com.mirego.trikot.foundation.concurrent.AtomicReference
 import org.reactivestreams.Processor
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
@@ -8,18 +7,12 @@ import org.reactivestreams.Subscription
 
 abstract class AbstractProcessor<T, R>(
     val parentPublisher: Publisher<T>
-) :
-    Processor<T, R> {
-    private val subscription: AtomicReference<Subscription?> =
-        AtomicReference(null)
+) : Processor<T, R> {
 
     abstract fun createSubscription(subscriber: Subscriber<in R>): ProcessorSubscription<T, R>
 
     override fun subscribe(s: Subscriber<in R>) {
         parentPublisher.subscribe(createSubscription(s))
-    }
-
-    private fun cancelActiveSubscription() {
     }
 
     override fun onSubscribe(s: Subscription) {


### PR DESCRIPTION
## Description
While reviewing https://github.com/mirego/trikot.streams/pull/60 I realized that there was dead private code in `AbstractProcessor`. This PR simply proposes to delete it to keep things nice and tidy.

## Motivation and Context
Simply to keep the code clean 

## How Has This Been Tested?
Ran the full test suite, no impact

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Not really a bug fix, but the change is non-breaking