### PR TITLE
Add Simplified JustPublisher

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -1,0 +1,11 @@
+package com.mirego.trikot.streams.reactive
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+class JustPublisher<T>(private val value: T) : Publisher<T> {
+    override fun subscribe(s: Subscriber<in T>) {
+        s.onNext(value)
+        s.onComplete()
+    }
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -20,7 +20,7 @@ object Publishers {
      */
     @JsName("just")
     fun <T> just(value: T): Publisher<T> {
-        return behaviorSubject(value).also { it.complete() }
+        return JustPublisher(value)
     }
 
     /**

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
@@ -1,0 +1,21 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import kotlin.test.Test
+
+class JustPublisherTests {
+
+    @Test
+    fun justPublisherEmitNextAndCompletion() {
+        val publisher = Publishers.just("VALUE")
+        var value = ""
+        var completion = false
+        publisher.subscribe(CancellableManager(),
+        onNext = { value = it },
+        onError = { throw IllegalStateException() },
+        onCompleted = { completion = true }
+        )
+        kotlin.test.assertEquals("VALUE", value)
+        kotlin.test.assertTrue(completion)
+    }
+}


### PR DESCRIPTION
## Description
When using `Publishers.just()` we create a simplified object that will emit the value and the completion in sync without going trough massive SequentialDispatchQueue process implemented in the PublishSubject.

## Motivation and Context
We had some case where we were creating so much elements, that garbage collection was taking noticeable time. Creating lots of ViewModels with lots of fields creates that. Moreover, we prevent freezing of many elements by doing so.

## How Has This Been Tested?
See attached tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
