### PR TITLE
Add swift combine extension to integrate publisher with SwiftUI

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -1,11 +1,25 @@
 package com.mirego.trikot.streams.reactive
 
+import com.mirego.trikot.foundation.concurrent.AtomicReference
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 
 class JustPublisher<T>(private val value: T) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
-        s.onNext(value)
-        s.onComplete()
+        val isCancelled = AtomicReference(false)
+        s.onSubscribe(object : Subscription {
+            override fun request(n: Long) {}
+
+            override fun cancel() {
+                isCancelled.compareAndSet(false, true)
+            }
+        })
+        if (!isCancelled.value) {
+            s.onNext(value)
+        }
+        if (!isCancelled.value) {
+            s.onComplete()
+        }
     }
 }

--- a/swift-extensions/combine/CombineExensions.swift
+++ b/swift-extensions/combine/CombineExensions.swift
@@ -1,0 +1,67 @@
+import Combine
+import TRIKOT_FRAMEWORK_NAME
+
+public class PublisherAdapter<T>: Combine.Publisher {
+    private let publisher: ShopCastFramework.Publisher
+
+    public typealias Output = T
+
+    public typealias Failure = Never
+
+    public func receive<S>(subscriber: S) where S: Combine.Subscriber, Failure == S.Failure, Output == S.Input {
+        publisher.subscribe(s: SubscriberAdapter(subscriber))
+    }
+
+    public init(_ publisher: ShopCastFramework.Publisher) {
+        self.publisher = publisher
+    }
+}
+
+public class SubscriberAdapter<S: Combine.Subscriber>: ShopCastFramework.Subscriber {
+    private let subscriber: S
+
+    public init(_ subscriber: S) {
+        self.subscriber = subscriber
+    }
+
+    public func onComplete() {
+        subscriber.receive(completion: .finished)
+    }
+
+    public func onError(t: KotlinThrowable) {
+        assert(false, "Error should be catch by KMP code. Error was: \(t)")
+    }
+
+    public func onNext(t: Any?) {
+        guard let t = t as? S.Input else { assert(false, "Invalid cast") }
+        _ = subscriber.receive(t)
+    }
+
+    public func onSubscribe(s: ShopCastFramework.Subscription) {
+        subscriber.receive(subscription: SubscriptionAdapter(s))
+    }
+}
+
+public class SubscriptionAdapter: Combine.Subscription {
+    private let subscription: ShopCastFramework.Subscription
+
+    init(_ subscription: ShopCastFramework.Subscription) {
+        self.subscription = subscription
+    }
+
+    public func request(_ demand: Subscribers.Demand) {
+        if let max = demand.max {
+            subscription.request(n: Int64(max))
+        }
+    }
+
+    public func cancel() {
+        subscription.cancel()
+    }
+}
+
+extension ShopCastFramework.Publisher {
+    public func asCombinePublisher<T>(type: T.Type) -> PublisherAdapter<T> {
+        PublisherAdapter<T>(self)
+    }
+}

--- a/swift-extensions/combine/README.md
+++ b/swift-extensions/combine/README.md
@@ -1,0 +1,28 @@
+# Trikot.streams swift combine extensions
+
+- Easily manage Trikot.streams publisher with swiftUI. 
+
+## Installation
+To use `Trikot.streams` swift combine extensions, you must export `streams` and `streams-iosarm64` module in your exported framework. See [Trikot.patron build.gradle file](https://github.com/mirego/trikot.patron/blob/master/common/build.gradle) for a sample use case.
+
+##### Setup Pod dependency
+```groovy
+  ENV['TRIKOT_FRAMEWORK_NAME']='ReplaceMeByTheFrameworkNameImportedByCocoaPods'
+  pod 'Trikot.streams/Combine', :git => 'https://github.com/mirego/trikot.streams.git'
+```
+Then, run `pod install`.
+
+### Observe
+```swift
+struct FeedView: View {
+    private let kotlinPublisher = CommonCode.getStringPublisher()
+    private let combinePublisher = kotlinPublisher.asCombinePublisher(type: String.self)
+    
+    @State private var text = ""
+    
+    var body: some View {
+        Text(self.text)
+            .onReceive(combinePublisher) { self.text = $0 }
+    }
+}
+```

--- a/trikot.streams.podspec
+++ b/trikot.streams.podspec
@@ -7,12 +7,24 @@ Pod::Spec.new do |spec|
   spec.license       = "MIT license"
   spec.author        = { "Martin Gagnon" => "mgagnon@mirego.com" }
   spec.source        = { :git => "https://github.com/mirego/trikot.streams.git", :tag => "#{spec.version}" }
-  spec.source_files  = "swift-extensions/*.swift"
   spec.static_framework = true
   
   spec.dependency ENV['TRIKOT_FRAMEWORK_NAME']
 
+  spec.default_subspec = 'streams'
+  
+  spec.subspec 'streams' do |ss|
+    ss.source_files  = "swift-extensions/*.swift"
+    ss.ios.deployment_target = '8.0'
+  end
+
+  spec.subspec 'Combine' do |combine|
+    combine.ios.deployment_target = '13.0'
+    combine.source_files = 'swift-extensions/combine/*.swift'
+  end
+
   spec.prepare_command = <<-CMD
-    sed -i '' "s/TRIKOT_FRAMEWORK_NAME/${TRIKOT_FRAMEWORK_NAME}/g" ./**/*.swift
+  sed -i '' "s/TRIKOT_FRAMEWORK_NAME/${TRIKOT_FRAMEWORK_NAME}/g" ./**/*.swift
+  sed -i '' "s/TRIKOT_FRAMEWORK_NAME/${TRIKOT_FRAMEWORK_NAME}/g" ./**/**/*.swift
   CMD
 end


### PR DESCRIPTION
## Description
- Make sure JustPublisher sends an OnSubscribe before sending value and completion
- Add an adapter between `org.reactiveStreams.publisher` and `Combine.Publisher`

## Motivation and Context
- Swift Combine.publisher needs a subscription before being able to receive events.
- Support SwiftUI onReceived method

## How Has This Been Tested?
In a separate project

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
