### PR TITLE
Fix multiple completion dispatched by the first processor

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.streams.reactive.processors
 
+import com.mirego.trikot.foundation.concurrent.AtomicReference
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 
@@ -11,12 +12,19 @@ class FirstProcessor<T>(parentPublisher: Publisher<T>) :
     }
 
     class FirstProcessorSubscription<T>(s: Subscriber<in T>) : ProcessorSubscription<T, T>(s) {
-
+        private val hasReceivedValue = AtomicReference(false)
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             if (t != null) {
+                hasReceivedValue.compareAndSet(false, true)
                 cancelActiveSubscription()
                 subscriber.onNext(t)
                 subscriber.onComplete()
+            }
+        }
+
+        override fun onComplete() {
+            if (!hasReceivedValue.value) {
+                super.onComplete()
             }
         }
     }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessorTests.kt
@@ -3,6 +3,8 @@ package com.mirego.trikot.streams.reactive.processors
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
 import com.mirego.trikot.streams.reactive.first
+import com.mirego.trikot.streams.reactive.map
+import com.mirego.trikot.streams.reactive.shared
 import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,5 +24,19 @@ class FirstProcessorTests {
 
         assertEquals("a", value)
         assertTrue { completed }
+    }
+
+    @Test
+    fun firstProcessorDoesNotForwardCompletionIfCompleted() {
+        val initialPublisher = Publishers.behaviorSubject<String>()
+        val publisher1 = initialPublisher.first()
+        val publisher2 = publisher1.map { it }.first().shared()
+
+        var result = ""
+        publisher2.subscribe(CancellableManager()) {
+            result += it
+        }
+        initialPublisher.value = "EXPECTED"
+        assertEquals("EXPECTED", result)
     }
 }


### PR DESCRIPTION
## Description
I was investigating a crash we had where completion was emitted twice on a stream. As the first processor emit a completed event without checking if the subscription is cancelled, we must make sure it does not emit a second completed event.

## How Has This Been Tested?
See updated test class

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
