### PR TITLE
To avoid a race condition, use the same serial queue in the Promise and in the BehaviorSubject

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/BehaviorSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/BehaviorSubjectImpl.kt
@@ -1,8 +1,11 @@
 package com.mirego.trikot.streams.reactive
 
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+
 open class BehaviorSubjectImpl<T>(
-    initialValue: T? = null
-) : PublishSubjectImpl<T>(), BehaviorSubject<T> {
+    initialValue: T? = null,
+    serialQueue: SynchronousSerialQueue = SynchronousSerialQueue()
+) : PublishSubjectImpl<T>(serialQueue), BehaviorSubject<T> {
 
     init {
         this.value = initialValue

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
@@ -5,12 +5,12 @@ import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
 import org.reactivestreams.Subscriber
 
-open class PublishSubjectImpl<T> : PublishSubject<T> {
+open class PublishSubjectImpl<T>(private val serialQueue: SynchronousSerialQueue = SynchronousSerialQueue()) :
+    PublishSubject<T> {
     private val subscriptions = AtomicListReference<PublisherSubscription<T>>()
     private val atomicValue = AtomicReference<T?>(null)
     private val atomicError = AtomicReference<Throwable?>(null)
     private val isCompleted = AtomicReference(false)
-    private val serialQueue = SynchronousSerialQueue()
     protected val hasSubscriptions
         get() = subscriptions.value.count() > 0
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
@@ -54,7 +54,7 @@ class Promise<T> internal constructor(
                 }
             )
 
-        internalCancellableManager.add {
+        cancellableManager?.add {
             serialQueue.dispatch {
                 isCancelled.setOrThrow(false, true)
 

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
@@ -17,8 +17,8 @@ class Promise<T> internal constructor(
     cancellableManager: CancellableManager? = null
 ) : Publisher<T> {
 
-    private val result = BehaviorSubjectImpl<T>()
     private val serialQueue = SynchronousSerialQueue()
+    private val result = BehaviorSubjectImpl<T>(serialQueue = serialQueue)
 
     private val isCancelled: AtomicReference<Boolean> = AtomicReference(false)
     private val internalCancellableManager: CancellableManager = CancellableManager().also {


### PR DESCRIPTION
## Description
A ConcurrentModificationException was thrown sometime when seeing a Promise. The problem was a race condition when setting the error on the result of the promise, the cancel of the promise was something setting the error a second time.

To avoid that we need to use the same serial queue in the PublishSubjectImpl and in the Promise. To achieve that we need to be able to specify the serial queue in the constructor of the PublishSubjectImpl.

At the same time, move the promise cancellation on the cancellable manager received in parameter.

## Motivation and Context
To fix a random crash

## How Has This Been Tested?
Tested in my project

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
