### PR TITLE
Add tvOS deployment target in streams subspec

### DIFF
--- a/trikot.streams.podspec
+++ b/trikot.streams.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'streams' do |ss|
     ss.source_files  = "swift-extensions/*.swift"
     ss.ios.deployment_target = '8.0'
+    ss.tvos.deployment_target = '9.0'
   end
 
   spec.subspec 'Combine' do |combine|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the tvOS deployment target in the _podspec_.

## Motivation and Context
<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the addition of the swift combine extension, it was no longer possible to compile trikot streams on tvOS. Adding the tvOS deployment target in the `streams` _subspec_ solves the issue.

## Notes

I didn't add the the tvOS deployment target for `Combine` subspec since i didn't test it. It could be added later on if required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
