### PR TITLE
Remove duplicated JS platform in build.gradle

### DIFF
--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -35,9 +35,6 @@ kotlin {
     ios()
     iosArm32('iosArm32')
     tvos()
-
-    // Restore JS engines when failing tests are fixed
-    js()
     js {
         browser()
         nodejs()


### PR DESCRIPTION
The `js()` platform shortcut was supposed to be removed before merge but it made its way on master so this PR removes it.