### PR TITLE
Add safeCombine extensions

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorExtensions.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.filter
 import com.mirego.trikot.streams.reactive.map
 import org.reactivestreams.Publisher
 
@@ -21,6 +22,24 @@ fun <T, R> Publisher<T>.combine(publisher: Publisher<R>): Publisher<Pair<T?, R?>
     return (this as Publisher<Any>).combine(listOf(publisher) as List<Publisher<Any>>)
         .map { list ->
             list[0] as? T to list[1] as? R
+        }
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T, R> Publisher<T>.safeCombine(publisher: Publisher<R>): Publisher<Pair<T, R>> {
+    return (this as Publisher<Any>).combine(listOf(publisher) as List<Publisher<Any>>)
+        .filter { list -> list[0] as? T != null && list[1] as? T != null }
+        .map { list ->
+            list[0] as T to list[1] as R
+        }
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T, R1, R2> Publisher<T>.safeCombine(publisher1: Publisher<R1>, publisher2: Publisher<R2>): Publisher<Triple<T, R1, R2>> {
+    return (this as Publisher<Any>).combine(listOf(publisher1, publisher2) as List<Publisher<Any>>)
+        .filter { list -> list[0] as? T != null && list[1] as? T != null && list[2] as? T != null }
+        .map { list ->
+            Triple(list[0] as T, list[1] as R1, list[2] as R2)
         }
 }
 

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
@@ -159,4 +159,59 @@ class CombineLatestProcessorTests {
 
         assertEquals(1, errorCount)
     }
+
+    @Test
+    fun whenUsingSafeCombineNoValueAreDispatchedWhenMissing() {
+        val firstPublisher = MockPublisher("a")
+        val secondPublisher = MockPublisher()
+        var firstValueReceived: String? = null
+        var secondValueReceived: String? = null
+
+        firstPublisher.safeCombine(secondPublisher)
+            .subscribe(CancellableManager()) { (value1, value2) ->
+                firstValueReceived = value1
+                secondValueReceived = value2
+            }
+
+        assertNull(firstValueReceived)
+        assertNull(secondValueReceived)
+    }
+
+    @Test
+    fun whenUsingSafeCombineValuesAreDispatchedWhenAllPublishersEmits() {
+        val firstPublisher = MockPublisher("a")
+        val secondPublisher = MockPublisher("b")
+        var firstValueReceived: String? = null
+        var secondValueReceived: String? = null
+
+        firstPublisher.safeCombine(secondPublisher)
+            .subscribe(CancellableManager()) { (value1, value2) ->
+                firstValueReceived = value1
+                secondValueReceived = value2
+            }
+
+        assertEquals("a", firstValueReceived)
+        assertEquals("b", secondValueReceived)
+    }
+
+    @Test
+    fun whenUsingSafeCombineWith2ArgumentsValuesAreDispatchedWhenAllPublishersEmits() {
+        val firstPublisher = MockPublisher("a")
+        val secondPublisher = MockPublisher("b")
+        val thirdPublisher = MockPublisher("c")
+        var firstValueReceived: String? = null
+        var secondValueReceived: String? = null
+        var thirdValueReceived: String? = null
+
+        firstPublisher.safeCombine(secondPublisher, thirdPublisher)
+            .subscribe(CancellableManager()) { (value1, value2, value3) ->
+                firstValueReceived = value1
+                secondValueReceived = value2
+                thirdValueReceived = value3
+            }
+
+        assertEquals("a", firstValueReceived)
+        assertEquals("b", secondValueReceived)
+        assertEquals("c", thirdValueReceived)
+    }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessorTests.kt
@@ -164,17 +164,12 @@ class CombineLatestProcessorTests {
     fun whenUsingSafeCombineNoValueAreDispatchedWhenMissing() {
         val firstPublisher = MockPublisher("a")
         val secondPublisher = MockPublisher()
-        var firstValueReceived: String? = null
-        var secondValueReceived: String? = null
-
+        var didDispatch = false
         firstPublisher.safeCombine(secondPublisher)
-            .subscribe(CancellableManager()) { (value1, value2) ->
-                firstValueReceived = value1
-                secondValueReceived = value2
+            .subscribe(CancellableManager()) {
+                didDispatch = true
             }
-
-        assertNull(firstValueReceived)
-        assertNull(secondValueReceived)
+        assertFalse(didDispatch)
     }
 
     @Test


### PR DESCRIPTION
## Description
Added 2 versions of safeCombine (pair and triple)

## Motivation and Context
* To have an easier way to use combine without having to work with nullable values.
* To stop copy pasting these lines in all of my projects

## How Has This Been Tested?
* In production in my last project for the past 4 months
* In unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
