### PR TITLE
Cancel the local cancellable manager in a following run loop

### DIFF
--- a/swift-extensions/TrikotPublisherExtensions.swift
+++ b/swift-extensions/TrikotPublisherExtensions.swift
@@ -6,7 +6,10 @@ extension NSObject {
         var cancellableManager = CancellableManager()
 
         deinit {
-            cancellableManager.cancel()
+            let localCancellable = cancellableManager
+            Foundation.DispatchQueue.main.async {
+                localCancellable.cancel()
+            }
         }
     }
 


### PR DESCRIPTION
## Description
There is an issue in Kotlin 1.4 where recursive GC is disallowed and we may receive this crash:
`/Users/teamcity/buildAgent/work/cae0e6559deed4c4/runtime/src/main/cpp/Memory.cpp:1605: runtime assert: Recursive GC is disallowed` when the common code release an object that triggers a cancel in Trikot.streams that also release Kotlin objects.

This PR fixes the issue by cancelling the subscriptions asynchronously. 

## Motivation and Context
See description

## How Has This Been Tested?
This change has been running since 2 month in 2 different projects.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
