### PR TITLE
Publish android sources

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -43,10 +43,16 @@ release {
     tagPrefix = 'android-ktx-'
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    archiveClassifier.set('sources')
+}
+
 publishing {
     publications {
         mavenAar(MavenPublication) {
             from components.android
+            artifact sourcesJar
         }
     }
 }


### PR DESCRIPTION
## Description
Publish sources along with aar artifact.

## Motivation and Context
Android sources for android-ktx module were not published with the aar artifact, making it difficult to debug in those classes.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
