### PR TITLE
Fix refreshable publisher concurency

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublishSubjectImpl.kt
@@ -31,10 +31,10 @@ open class PublishSubjectImpl<T>(private val serialQueue: SynchronousSerialQueue
 
                 value?.let {
                     error?.let {
-                        throw IllegalStateException("Value should not be set after an error.")
+                        throw IllegalStateException("Value should not be set after an error.\nValue: $value\nError:$error")
                     }
                     if (isCompleted.value) {
-                        throw IllegalStateException("Value should not be set after publisher has completed.")
+                        throw IllegalStateException("Value should not be set after publisher has completed.\nValue: $value")
                     }
                     dispatchValueToSubscribers(it)
                 }
@@ -49,7 +49,7 @@ open class PublishSubjectImpl<T>(private val serialQueue: SynchronousSerialQueue
             serialQueue.dispatch {
                 value = null
                 if (isCompleted.value) {
-                    throw IllegalStateException("Error should not be set after publisher has completed.")
+                    throw IllegalStateException("Error should not be set after publisher has completed.\nError: $error\nValue: $value")
                 }
                 atomicError.setOrThrow(
                     null,


### PR DESCRIPTION
## Description
Race condition on subscription/unsubscription and refresh may happen in the RefreshablePublisher. To correct this, we make sure doCancel and doExecuteBlock are in the same serial queue as the publisher.

Also add some information in the publisher race condition

## How Has This Been Tested?
In a separate project.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
