### PR TITLE
Remove a workaround for a bug in the compiler fixed in Kotlin 1.4.20

### DIFF
--- a/swift-extensions/TrikotPublisherExtensions.swift
+++ b/swift-extensions/TrikotPublisherExtensions.swift
@@ -6,10 +6,7 @@ extension NSObject {
         var cancellableManager = CancellableManager()
 
         deinit {
-            let localCancellable = cancellableManager
-            Foundation.DispatchQueue.main.async {
-                localCancellable.cancel()
-            }
+            cancellableManager.cancel()
         }
     }
 


### PR DESCRIPTION
## Description
This PR revert the temporary workaround introduced in #72 to bypass a bug introduced in the Kotlin compiler in `1.4.0`. The bug has been fixed in Kotlin `1.4.20` and the workaround is no longer needed.

Original issue:
[KT-42275 "Memory.cpp:1605: runtime assert: Recursive GC is disallowed" sometimes when using Kotlin from Swift deinit](https://youtrack.jetbrains.com/issue/KT-42275)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
