### PR TITLE
On error resume next operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -14,6 +14,8 @@ import com.mirego.trikot.streams.reactive.processors.FirstProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor
+import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextBlock
+import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.RetryWhenProcessor
@@ -151,3 +153,11 @@ inline fun <T, reified R : T> Publisher<T>.filterIs() =
     filter { it is R }.map { it as R }
 
 fun Publisher<Boolean>.reverse() = map { !it }
+
+/**
+ * The onErrorResumeNext operator intercepts an onError notification from the source Publisher and,
+ * instead of passing it through to any publishers, replaces it with some other item or sequence of items,
+ * potentially allowing the resulting Publisher to terminate normally or not to terminate at all.
+ */
+fun <T> Publisher<T>.onErrorResumeNext(block: OnErrorResumeNextBlock<T>): Publisher<T> =
+    OnErrorResumeNextProcessor(this, block)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessor.kt
@@ -1,0 +1,59 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.observeOn
+import com.mirego.trikot.streams.reactive.subscribe
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+typealias OnErrorResumeNextBlock<T> = (Throwable) -> Publisher<T>
+
+class OnErrorResumeNextProcessor<T>(parentPublisher: Publisher<T>, private var block: OnErrorResumeNextBlock<T>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return OnErrorResumeNextProcessorSubscription(subscriber, block)
+    }
+
+    class OnErrorResumeNextProcessorSubscription<T>(
+        private val subscriber: Subscriber<in T>,
+        private val block: OnErrorResumeNextBlock<T>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+        private val cancellableManagerProvider = CancellableManagerProvider()
+        private val currentPublisher = AtomicReference<Publisher<T>?>(null)
+        private val onErrorValidation = AtomicReference(0)
+        private val serialQueue = SynchronousSerialQueue()
+
+        override fun onCancel(s: Subscription) {
+            super.onCancel(s)
+            cancellableManagerProvider.cancel()
+        }
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            subscriber.onNext(t)
+        }
+
+        override fun onError(t: Throwable) {
+            onErrorValidation.setOrThrow(0, 1)
+
+            val newPublisher = try {
+                block(t)
+            } catch (e: StreamsProcessorException) {
+                subscriber.onError(e)
+                return
+            }
+
+            currentPublisher.setOrThrow(currentPublisher.value, newPublisher)
+            newPublisher.observeOn(serialQueue).subscribe(cancellableManagerProvider.cancelPreviousAndCreate(),
+                onNext = { subscriber.onNext(it) },
+                onError = { subscriber.onError(it) },
+                onCompleted = { subscriber.onComplete() })
+
+            onErrorValidation.setOrThrow(1, 0)
+        }
+    }
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessor.kt
@@ -24,7 +24,6 @@ class OnErrorResumeNextProcessor<T>(parentPublisher: Publisher<T>, private var b
         private val block: OnErrorResumeNextBlock<T>
     ) : ProcessorSubscription<T, T>(subscriber) {
         private val cancellableManagerProvider = CancellableManagerProvider()
-        private val currentPublisher = AtomicReference<Publisher<T>?>(null)
         private val onErrorValidation = AtomicReference(0)
         private val serialQueue = SynchronousSerialQueue()
 
@@ -47,11 +46,12 @@ class OnErrorResumeNextProcessor<T>(parentPublisher: Publisher<T>, private var b
                 return
             }
 
-            currentPublisher.setOrThrow(currentPublisher.value, newPublisher)
-            newPublisher.observeOn(serialQueue).subscribe(cancellableManagerProvider.cancelPreviousAndCreate(),
+            newPublisher.observeOn(serialQueue).subscribe(
+                cancellableManagerProvider.cancelPreviousAndCreate(),
                 onNext = { subscriber.onNext(it) },
                 onError = { subscriber.onError(it) },
-                onCompleted = { subscriber.onComplete() })
+                onCompleted = { subscriber.onComplete() }
+            )
 
             onErrorValidation.setOrThrow(1, 0)
         }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/OnErrorResumeNextProcessorTests.kt
@@ -1,0 +1,117 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.MockPublisher
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.just
+import com.mirego.trikot.streams.reactive.onErrorResumeNext
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OnErrorResumeNextProcessorTests {
+    @Test
+    fun onErrorResumeNext_withNextAndCompletion() {
+        val publisher = Publishers.behaviorSubject<String>()
+        val expectedError = Exception()
+        publisher.error = expectedError
+        val expectedValue = "EXPECTED_VALUE"
+        var receivedError: Throwable? = null
+        var receivedValue: String? = null
+        var isCompleted = false
+
+        publisher.onErrorResumeNext {
+            receivedError = it
+            expectedValue.just()
+        }.subscribe(
+            CancellableManager(),
+            onNext = { receivedValue = it },
+            onError = { throw IllegalStateException("Should not return an error") },
+            onCompleted = { isCompleted = true }
+        )
+
+        assertEquals(expectedError, receivedError)
+        assertEquals(expectedValue, receivedValue)
+        assertTrue(isCompleted, "Should be completed")
+    }
+
+    @Test
+    fun onErrorResumeNext_withNextAndNoCompletion() {
+        val publisher = Publishers.behaviorSubject<String>()
+        val expectedError = Exception()
+        publisher.error = expectedError
+        val expectedValue = "EXPECTED_VALUE"
+        var receivedError: Throwable? = null
+        var receivedValue: String? = null
+        var isCompleted = false
+
+        publisher.onErrorResumeNext {
+            receivedError = it
+            Publishers.behaviorSubject(expectedValue)
+        }.subscribe(
+            CancellableManager(),
+            onNext = { receivedValue = it },
+            onError = { throw IllegalStateException("Should not return an error") },
+            onCompleted = { isCompleted = true }
+        )
+
+        assertEquals(expectedError, receivedError)
+        assertEquals(expectedValue, receivedValue)
+        assertFalse(isCompleted, "Should be not be completed")
+    }
+
+    @Test
+    fun onErrorResumeNext_withError() {
+        val publisher = Publishers.behaviorSubject<String>()
+        val expectedError = Exception()
+        publisher.error = expectedError
+        val resumeError = Exception()
+        var receivedError: Throwable? = null
+        var receivedResumeError: Throwable? = null
+        var isCompleted = false
+
+        publisher.onErrorResumeNext {
+            receivedError = it
+            Publishers.error(resumeError)
+        }.subscribe(
+            CancellableManager(),
+            onNext = { throw IllegalStateException("Should not return a value") },
+            onError = { receivedResumeError = it },
+            onCompleted = { isCompleted = true }
+        )
+
+        assertEquals(expectedError, receivedError)
+        assertEquals(resumeError, receivedResumeError)
+        assertFalse(isCompleted, "Should not be completed")
+    }
+
+    @Test
+    fun onErrorResumeNext_withEmpty() {
+        val publisher = Publishers.behaviorSubject<String>()
+        val expectedError = Exception()
+        publisher.error = expectedError
+        var isCompleted = false
+
+        publisher.onErrorResumeNext {
+            Publishers.empty()
+        }.subscribe(
+            CancellableManager(),
+            onNext = { throw IllegalStateException("Should not return a value") },
+            onError = { throw IllegalStateException("Should not return an error") },
+            onCompleted = { isCompleted = true }
+        )
+
+        assertTrue(isCompleted, "Should be completed")
+    }
+
+    @Test
+    fun parentIsUnsubscribedOnError() {
+        val parentPublisher = MockPublisher().also { it.error = Throwable() }
+        parentPublisher.onErrorResumeNext { "a".just() }.subscribe(CancellableManager()) {
+        }
+
+        assertFalse(parentPublisher.getHasSubscriptions)
+    }
+}


### PR DESCRIPTION
## Description
Implement onErrorResumeNext operator
The onErrorResumeNext operator intercepts an onError notification from the source Publisher and,
instead of passing it through to any publishers, replaces it with some other item or sequence of items,
potentially allowing the resulting Publisher to terminate normally or not to terminate at all.

## Motivation and Context
This RxOperator was missing out.
http://reactivex.io/documentation/operators/catch.html

## How Has This Been Tested?
This was unit tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
