### PR TITLE
Implement merge operator from reactive spec

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -170,8 +170,8 @@ fun <T> Publisher<T>.onErrorResumeNext(block: OnErrorResumeNextBlock<T>): Publis
  * and will terminate the merged Publisher.
  * onComplete notification will only be sent if all merged Publishers are completed
  */
-fun <T> Publisher<T>.merge(publishers: List<Publisher<out T>>) : Publisher<T> =
+fun <T> Publisher<T>.merge(publishers: List<Publisher<out T>>): Publisher<T> =
     MergeProcessor(this, publishers)
 
-fun  <T> Publisher<T>.merge(vararg publishers: Publisher<out T>): Publisher<T> =
+fun <T> Publisher<T>.merge(vararg publishers: Publisher<out T>): Publisher<T> =
     MergeProcessor(this, publishers.toList())

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -13,6 +13,7 @@ import com.mirego.trikot.streams.reactive.processors.FilterProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.FirstProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessor
 import com.mirego.trikot.streams.reactive.processors.MapProcessorBlock
+import com.mirego.trikot.streams.reactive.processors.MergeProcessor
 import com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextBlock
 import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextProcessor
@@ -161,3 +162,16 @@ fun Publisher<Boolean>.reverse() = map { !it }
  */
 fun <T> Publisher<T>.onErrorResumeNext(block: OnErrorResumeNextBlock<T>): Publisher<T> =
     OnErrorResumeNextProcessor(this, block)
+
+/**
+ * Combine multiple Observables into one by merging their emissions
+ * Merge may interleave the items emitted by the merged Publishers so order is not guaranteed
+ * onError notification from any of the source Publishers will immediately be passed through to subscribers
+ * and will terminate the merged Publisher.
+ * onComplete notification will only be sent if all merged Publishers are completed
+ */
+fun <T> Publisher<T>.merge(publishers: List<Publisher<out T>>) : Publisher<T> =
+    MergeProcessor(this, publishers)
+
+fun  <T> Publisher<T>.merge(vararg publishers: Publisher<out T>): Publisher<T> =
+    MergeProcessor(this, publishers.toList())

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessor.kt
@@ -39,7 +39,7 @@ class MergeProcessor<T>(parentPublisher: Publisher<T>, private val publishers: L
         override fun onComplete() {
             dispatchCompletedIfAllCompleted()
         }
-        
+
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             subscriber.onNext(t)
         }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessor.kt
@@ -1,0 +1,78 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
+import com.mirego.trikot.streams.reactive.observeOn
+import com.mirego.trikot.streams.reactive.subscribe
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+class MergeProcessor<T>(parentPublisher: Publisher<T>, private val publishers: List<Publisher<out T>>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return MergeProcessorSubscription(subscriber, publishers)
+    }
+
+    class MergeProcessorSubscription<T>(
+        private val subscriber: Subscriber<in T>,
+        private val publishers: List<Publisher<out T>>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+        private val cancellableManagerProvider = CancellableManagerProvider()
+        private val incompleteCount = AtomicReference(publishers.size + 1)
+        private val serialQueue = SynchronousSerialQueue()
+        private val hasSubscribed = AtomicReference(false)
+
+        override fun onSubscribe(s: Subscription) {
+            super.onSubscribe(s)
+            subscribeToCombinedPublishersIfNeeded()
+        }
+
+        override fun onCancel(s: Subscription) {
+            super.onCancel(s)
+            cancellableManagerProvider.cancel()
+            hasSubscribed.compareAndSet(true, false)
+        }
+
+        override fun onComplete() {
+            dispatchCompletedIfAllCompleted()
+        }
+        
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            subscriber.onNext(t)
+        }
+
+        override fun onError(t: Throwable) {
+            super.onError(t)
+            cancellableManagerProvider.cancelPreviousAndCreate()
+            cancelActiveSubscription()
+        }
+
+        private fun subscribeToCombinedPublishersIfNeeded() {
+            if (hasSubscribed.compareAndSet(false, true)) {
+                val cancellableManager = cancellableManagerProvider.cancelPreviousAndCreate()
+
+                publishers.forEach { publisher ->
+                    publisher.observeOn(serialQueue).subscribe(
+                        cancellableManager,
+                        onNext = { onNext(it) },
+                        onError = { onError(it) },
+                        onCompleted = { dispatchCompletedIfAllCompleted() }
+                    )
+                }
+            }
+        }
+
+        private fun dispatchCompletedIfAllCompleted() {
+            serialQueue.dispatch {
+                val newValue = incompleteCount.value - 1
+                incompleteCount.setOrThrow(incompleteCount.value, newValue)
+                if (newValue == 0) {
+                    subscriber.onComplete()
+                }
+            }
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
@@ -1,0 +1,87 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.just
+import com.mirego.trikot.streams.reactive.merge
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MergeProcessorTests {
+
+    @Test
+    fun whenAllPublishersCompleteMergeCompletes() {
+        val firstPublisher = Publishers.behaviorSubject("1")
+        val secondPublisher = Publishers.behaviorSubject("2")
+        val receivedValues = mutableListOf<String>()
+        var completed = false
+        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+            onNext = { receivedValues += it },
+            onError = { throw IllegalStateException() },
+            onCompleted = { completed = true })
+
+        assertTrue(receivedValues.containsAll(listOf("1", "2")))
+        assertTrue(completed)
+    }
+
+    @Test
+    fun mergeWaitsForAllPublishersToComplete() {
+        val firstPublisher = Publishers.just("1")
+        val secondPublisher = Publishers.behaviorSubject("2")
+        val receivedValues = mutableListOf<String>()
+        var completed = false
+        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+            onNext = { receivedValues += it },
+            onError = { throw IllegalStateException() },
+            onCompleted = { completed = true })
+
+        assertTrue(receivedValues.containsAll(listOf("1", "2")))
+        assertFalse(completed)
+
+        secondPublisher.complete()
+        assertTrue(completed)
+    }
+
+    @Test
+    fun mergeDispatchErrorsImmediately() {
+        val expectedError = Throwable()
+        val firstPublisher = Publishers.behaviorSubject<String>()
+        val secondPublisher = Publishers.behaviorSubject<String>()
+        val receivedValues = mutableListOf<String>()
+        var receivedError: Throwable? = null
+
+        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+            onNext = { receivedValues += it },
+            onError = { receivedError = it},
+            onCompleted = { throw IllegalStateException() })
+
+        firstPublisher.value = "1"
+        secondPublisher.error = expectedError
+        firstPublisher.value = "2"
+
+        assertEquals(listOf("1"), receivedValues)
+        assertEquals(expectedError, receivedError)
+    }
+
+    @Test
+    fun mergeWithALotOfPublishersWaitOnCompletionToComplete() {
+        val firstPublisher = Publishers.behaviorSubject("1")
+        val allPublishers = (2..100).map { it.toString().just() }
+        val receivedValues = mutableListOf<String>()
+        var completed = false
+        firstPublisher.merge(allPublishers).subscribe(CancellableManager(),
+            onNext = { receivedValues += it },
+            onError = { throw IllegalStateException() },
+            onCompleted = { completed = true })
+
+        assertEquals(100, receivedValues.size)
+        assertFalse(completed)
+
+        firstPublisher.complete()
+        assertTrue(completed)
+    }
+
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
@@ -18,10 +18,12 @@ class MergeProcessorTests {
         val secondPublisher = Publishers.behaviorSubject<String>()
         val receivedValues = mutableListOf<String>()
         var completed = false
-        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+        firstPublisher.merge(secondPublisher).subscribe(
+            CancellableManager(),
             onNext = { receivedValues += it },
             onError = { throw IllegalStateException() },
-            onCompleted = { completed = true })
+            onCompleted = { completed = true }
+        )
 
         firstPublisher.value = "1"
         secondPublisher.value = "2"
@@ -38,10 +40,12 @@ class MergeProcessorTests {
         val secondPublisher = Publishers.behaviorSubject("2")
         val receivedValues = mutableListOf<String>()
         var completed = false
-        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+        firstPublisher.merge(secondPublisher).subscribe(
+            CancellableManager(),
             onNext = { receivedValues += it },
             onError = { throw IllegalStateException() },
-            onCompleted = { completed = true })
+            onCompleted = { completed = true }
+        )
 
         assertTrue(receivedValues.containsAll(listOf("1", "2")))
         assertFalse(completed)
@@ -58,10 +62,12 @@ class MergeProcessorTests {
         val receivedValues = mutableListOf<String>()
         var receivedError: Throwable? = null
 
-        firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
+        firstPublisher.merge(secondPublisher).subscribe(
+            CancellableManager(),
             onNext = { receivedValues += it },
-            onError = { receivedError = it},
-            onCompleted = { throw IllegalStateException() })
+            onError = { receivedError = it },
+            onCompleted = { throw IllegalStateException() }
+        )
 
         firstPublisher.value = "1"
         secondPublisher.error = expectedError
@@ -77,10 +83,12 @@ class MergeProcessorTests {
         val allPublishers = (2..100).map { it.toString().just() }
         val receivedValues = mutableListOf<String>()
         var completed = false
-        firstPublisher.merge(allPublishers).subscribe(CancellableManager(),
+        firstPublisher.merge(allPublishers).subscribe(
+            CancellableManager(),
             onNext = { receivedValues += it },
             onError = { throw IllegalStateException() },
-            onCompleted = { completed = true })
+            onCompleted = { completed = true }
+        )
 
         assertEquals(100, receivedValues.size)
         assertFalse(completed)
@@ -88,5 +96,4 @@ class MergeProcessorTests {
         firstPublisher.complete()
         assertTrue(completed)
     }
-
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/MergeProcessorTests.kt
@@ -14,8 +14,8 @@ class MergeProcessorTests {
 
     @Test
     fun whenAllPublishersCompleteMergeCompletes() {
-        val firstPublisher = Publishers.behaviorSubject("1")
-        val secondPublisher = Publishers.behaviorSubject("2")
+        val firstPublisher = Publishers.behaviorSubject<String>()
+        val secondPublisher = Publishers.behaviorSubject<String>()
         val receivedValues = mutableListOf<String>()
         var completed = false
         firstPublisher.merge(secondPublisher).subscribe(CancellableManager(),
@@ -23,7 +23,12 @@ class MergeProcessorTests {
             onError = { throw IllegalStateException() },
             onCompleted = { completed = true })
 
-        assertTrue(receivedValues.containsAll(listOf("1", "2")))
+        firstPublisher.value = "1"
+        secondPublisher.value = "2"
+        firstPublisher.complete()
+        secondPublisher.complete()
+
+        assertEquals(listOf("1", "2"), receivedValues)
         assertTrue(completed)
     }
 


### PR DESCRIPTION
## Description
Combine multiple Observables into one by merging their emissions
Merge may interleave the items emitted by the merged Publishers so order is not guaranteed
onError notification from any of the source Publishers will immediately be passed through to subscribers
and will terminate the merged Publisher.
onComplete notification will only be sent if all merged Publishers are completed

![Screen Shot 2020-12-11 at 12 34 47 PM](https://user-images.githubusercontent.com/618592/101935552-481a5b80-3bad-11eb-8667-4658b0d4c22e.png)

http://reactivex.io/documentation/operators/merge.html

## Motivation and Context
This operator was missing out.

## How Has This Been Tested?
Unit tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
