### PR TITLE
Prevent never publisher from freezing subscribers

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,6 +1,8 @@
 package com.mirego.trikot.streams.reactive
 
 import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import kotlin.js.JsName
 
 object Publishers {
@@ -38,7 +40,17 @@ object Publishers {
      */
     @JsName("never")
     fun <T> never(): Publisher<T> {
-        return publishSubject()
+		return object: Publisher<T> {
+			override fun subscribe(s: Subscriber<in T>) {
+				s.onSubscribe(object: Subscription {
+					override fun request(n: Long) {
+					}
+
+					override fun cancel() {
+					}
+				})
+			}
+		}
     }
 
     /**

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -40,17 +40,17 @@ object Publishers {
      */
     @JsName("never")
     fun <T> never(): Publisher<T> {
-		return object: Publisher<T> {
-			override fun subscribe(s: Subscriber<in T>) {
-				s.onSubscribe(object: Subscription {
-					override fun request(n: Long) {
-					}
+        return object : Publisher<T> {
+            override fun subscribe(s: Subscriber<in T>) {
+                s.onSubscribe(object : Subscription {
+                    override fun request(n: Long) {
+                    }
 
-					override fun cancel() {
-					}
-				})
-			}
-		}
+                    override fun cancel() {
+                    }
+                })
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Instead of using an actual PublishSubject, simply use a emty barebone implementation that does not keep a reference to it’s subscribers

## Motivation and Context
In Kotlin/Native projects, when subscribing to a `.never()` publisher, you ended up frozen because the underlying implementation was a complete PublishSubject. These useless freeze can affect performance when they occur a lot, for example in a UICollectionView with complex cells.

## How Has This Been Tested?
- Hypothesis tested in app. 
- Unit tests still passing. 
- No change in public behaviour

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
