### PR TITLE
Implement scan operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -21,6 +21,8 @@ import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.RetryWhenProcessor
 import com.mirego.trikot.streams.reactive.processors.RetryWhenPublisherBlock
+import com.mirego.trikot.streams.reactive.processors.ScanProcessor
+import com.mirego.trikot.streams.reactive.processors.ScanProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.SharedProcessor
 import com.mirego.trikot.streams.reactive.processors.SubscribeOnProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
@@ -175,3 +177,12 @@ fun <T> Publisher<T>.merge(publishers: List<Publisher<out T>>): Publisher<T> =
 
 fun <T> Publisher<T>.merge(vararg publishers: Publisher<out T>): Publisher<T> =
     MergeProcessor(this, publishers.toList())
+
+/**
+ * Apply a function to each item emitted by a Publisher, sequentially,
+ * and emit each successive value
+ * This sort of operator is sometimes called an “accumulator” in other contexts.
+ */
+fun <T> Publisher<T>.scan(block: ScanProcessorBlock<T>): Publisher<T> {
+    return ScanProcessor(this, block)
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -184,5 +184,9 @@ fun <T> Publisher<T>.merge(vararg publishers: Publisher<out T>): Publisher<T> =
  * This sort of operator is sometimes called an “accumulator” in other contexts.
  */
 fun <T> Publisher<T>.scan(block: ScanProcessorBlock<T>): Publisher<T> {
-    return ScanProcessor(this, block)
+    return ScanProcessor(this, null, block)
+}
+
+fun <T> Publisher<T>.scan(initialValue: T, block: ScanProcessorBlock<T>): Publisher<T> {
+    return ScanProcessor(this, initialValue, block)
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
@@ -1,0 +1,43 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.processors.AbstractProcessor
+import com.mirego.trikot.streams.reactive.processors.ProcessorSubscription
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+typealias ScanProcessorBlock<T> = (acc: T, current: T) -> T
+
+class ScanProcessor<T>(parentPublisher: Publisher<T>, private val block: ScanProcessorBlock<T>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return MapProcessorSubscription(subscriber, block)
+    }
+
+    class MapProcessorSubscription<T>(
+        subscriber: Subscriber<in T>,
+        private val block: ScanProcessorBlock<T>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+
+        private val atomicValue = AtomicReference<T?>(null)
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            val v = atomicValue.value
+            if (v == null) {
+                atomicValue.setOrThrow(null, t)
+                subscriber.onNext(t)
+            } else {
+                val result = try {
+                    block(v, t)
+                } catch (exception: StreamsProcessorException) {
+                    onError(exception)
+                    return
+                }
+                atomicValue.setOrThrow(v, result)
+                subscriber.onNext(result)
+            }
+        }
+    }
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
@@ -2,8 +2,6 @@ package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.streams.reactive.StreamsProcessorException
-import com.mirego.trikot.streams.reactive.processors.AbstractProcessor
-import com.mirego.trikot.streams.reactive.processors.ProcessorSubscription
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 
@@ -13,10 +11,10 @@ class ScanProcessor<T>(parentPublisher: Publisher<T>, private val block: ScanPro
     AbstractProcessor<T, T>(parentPublisher) {
 
     override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
-        return MapProcessorSubscription(subscriber, block)
+        return ScanProcessorSubscription(subscriber, block)
     }
 
-    class MapProcessorSubscription<T>(
+    class ScanProcessorSubscription<T>(
         subscriber: Subscriber<in T>,
         private val block: ScanProcessorBlock<T>
     ) : ProcessorSubscription<T, T>(subscriber) {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessor.kt
@@ -7,19 +7,20 @@ import org.reactivestreams.Subscriber
 
 typealias ScanProcessorBlock<T> = (acc: T, current: T) -> T
 
-class ScanProcessor<T>(parentPublisher: Publisher<T>, private val block: ScanProcessorBlock<T>) :
+class ScanProcessor<T>(parentPublisher: Publisher<T>, private val initialValue: T?, private val block: ScanProcessorBlock<T>) :
     AbstractProcessor<T, T>(parentPublisher) {
 
     override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
-        return ScanProcessorSubscription(subscriber, block)
+        return ScanProcessorSubscription(subscriber, initialValue, block)
     }
 
     class ScanProcessorSubscription<T>(
         subscriber: Subscriber<in T>,
+        initialValue: T?,
         private val block: ScanProcessorBlock<T>
     ) : ProcessorSubscription<T, T>(subscriber) {
 
-        private val atomicValue = AtomicReference<T?>(null)
+        private val atomicValue = AtomicReference<T?>(initialValue)
 
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             val v = atomicValue.value

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
@@ -19,14 +19,17 @@ class ScanProcessorTests {
 
         publisher
             .scan { acc, current -> acc + current }
-            .subscribe(CancellableManager(),
+            .subscribe(
+                CancellableManager(),
                 onNext = {
                     receivedResults.add(it)
-                }, onError = {
-
-                }, onCompleted = {
+                },
+                onError = {
+                },
+                onCompleted = {
                     completed = true
-                })
+                }
+            )
 
         publisher.value = 1
         publisher.value = 2

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
@@ -42,6 +42,36 @@ class ScanProcessorTests {
     }
 
     @Test
+    fun testScanWithInitialValue() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .scan(10) { acc, current -> acc + current }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+        publisher.complete()
+
+        assertEquals(listOf(10, 11, 13, 16, 20), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
     fun testMappingStreamsProcessorException() {
         val publisher = Publishers.behaviorSubject("a")
         val expectedException = StreamsProcessorException()

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
@@ -1,0 +1,76 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.scan
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ScanProcessorTests {
+    @Test
+    fun testScan() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .scan { acc, current -> acc + current }
+            .subscribe(CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                }, onError = {
+
+                }, onCompleted = {
+                    completed = true
+                })
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+        publisher.complete()
+
+        assertEquals(listOf(0, 1, 3, 6, 10), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testMappingStreamsProcessorException() {
+        val publisher = Publishers.behaviorSubject("a")
+        val expectedException = StreamsProcessorException()
+        var receivedException: StreamsProcessorException? = null
+
+        publisher.scan { _, _ -> throw expectedException }.subscribe(
+            CancellableManager(),
+            onNext = {
+            },
+            onError = { receivedException = it as StreamsProcessorException }
+        )
+
+        publisher.value = "b"
+
+        assertEquals(expectedException, receivedException)
+    }
+
+    @Test
+    fun testMappingAnyException() {
+        val publisher = Publishers.behaviorSubject("a")
+
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        var receivedException: StreamsProcessorException? = null
+
+        assertFailsWith(IllegalStateException::class) {
+            publisher.scan { _, _ -> throw IllegalStateException() }.subscribe(
+                CancellableManager(),
+                onNext = {
+                },
+                onError = { receivedException = it as StreamsProcessorException }
+            )
+            publisher.value = "b"
+        }
+    }
+}


### PR DESCRIPTION
## Description
This implements the scan operator based on the reactive spec

_apply a function to each item emitted by a Publisher, sequentially, and emit each successive value_
![image](https://user-images.githubusercontent.com/618592/104949537-1e630a00-598d-11eb-8a6b-7b488fb497cc.png)
Source: http://reactivex.io/documentation/operators/scan.html

## Motivation and Context
The scan operator helps in contexts where we must transform emitted values using previous accumulation. One use case is the accumulation of ints but it does come useful in more cases where you want to return a new value based on previous ones.

## How Has This Been Tested?
Unit tested and also tested in a real use case.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
