### PR TITLE
Fix race condition crash in CancellableManager

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
@@ -29,8 +29,9 @@ class CancellableManager : Cancellable {
     }
 
     override fun cancel() {
-        isCancelled.setOrThrow(isCancelled.value, true)
-        doCancelAll()
+        if (isCancelled.compareAndSet(isCancelled.value, true)) {
+            doCancelAll()
+        }
     }
 
     private fun doCancelAll() {


### PR DESCRIPTION
## Description
This fixes a possible race condition crash that could happen when isCancelled value was changed from another thread.

We now use compareAndSet which checks if the value was already changed and skips doCancelAll if it was already

## Motivation and Context
We had this stack trace in our app
```
Fatal Exception: java.util.ConcurrentModificationException: Unable to set true to AtomicReference. Possible Race Condition. Expected value false was true. null
       at com.mirego.trikot.foundation.concurrent.AtomicReference.setOrThrow(AtomicReference.java:19)
       at com.mirego.trikot.foundation.concurrent.AtomicReference.setOrThrow(AtomicReference.java:13)
       at com.mirego.trikot.streams.cancellable.CancellableManager.cancel(CancellableManager.java:32)
       at com.mirego.trikot.streams.cancellable.CancellableManagerProvider.cancel(CancellableManagerProvider.java:18)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription.onCancel(SwitchMapProcessor.java:35)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onCancel(ProcessorSubscription.java:39)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.onCancel(CombineLatestProcessor.java:39)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onCancel(ProcessorSubscription.java:39)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onCancel(ProcessorSubscription.java:39)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.SubscriberFromBlock$onSubscribe$1.cancel(SubscriberFromBlock.java:28)
       at com.mirego.trikot.streams.cancellable.CancellableManager$doCancelAll$1.invoke(CancellableManager.java:41)
       at com.mirego.trikot.streams.cancellable.CancellableManager$doCancelAll$1.invoke(CancellableManager.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.java:20)
       at com.mirego.trikot.streams.cancellable.CancellableManager.doCancelAll(CancellableManager.java:37)
       at com.mirego.trikot.streams.cancellable.CancellableManager.cancel(CancellableManager.java:33)
       at com.mirego.trikot.streams.cancellable.CancellableManager$doCancelAll$1.invoke(CancellableManager.java:41)
       at com.mirego.trikot.streams.cancellable.CancellableManager$doCancelAll$1.invoke(CancellableManager.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.java:20)
       at com.mirego.trikot.streams.cancellable.CancellableManager.doCancelAll(CancellableManager.java:37)
       at com.mirego.trikot.streams.cancellable.CancellableManager.cancel(CancellableManager.java:33)
       at com.mirego.trikot.streams.cancellable.CancellableManagerProvider.cancel(CancellableManagerProvider.java:18)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription.onCancel(SwitchMapProcessor.java:35)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onCancel(ProcessorSubscription.java:39)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onCancel(ProcessorSubscription.java:39)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription$onSubscribe$subscription$1.cancel(ProcessorSubscription.java:49)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.cancelActiveSubscription(ProcessorSubscription.java:35)
       at com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessor$OnErrorReturnSubscription.onError(OnErrorReturnProcessor.java:25)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription.onError(SwitchMapProcessor.java:73)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription$onNext$2.invoke(SwitchMapProcessor.java:61)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription$onNext$2.invoke(SwitchMapProcessor.java:22)
       at com.mirego.trikot.streams.reactive.SubscriberFromBlock.onError(SubscriberFromBlock.java:42)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription.access$onError$s-1055476332(ObserveOnProcessor.java:25)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription$onError$1.invoke(ObserveOnProcessor.java:37)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription$onError$1.invoke(ObserveOnProcessor.java:25)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.java:20)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchQueueKt.dispatch(DispatchQueueKt.java:15)
       at co```
m.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription.onError(ObserveOnProcessor.java:37)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.onError(CombineLatestProcessor.java:56)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription$subscribeToCombinedPublishersIfNeeded$$inlined$forEachIndexed$lambda$2.invoke(CombineLatestProcessor.java:90)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription$subscribeToCombinedPublishersIfNeeded$$inlined$forEachIndexed$lambda$2.invoke(CombineLatestProcessor.java:23)
       at com.mirego.trikot.streams.reactive.SubscriberFromBlock.onError(SubscriberFromBlock.java:42)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription.access$onError$s-1055476332(ObserveOnProcessor.java:25)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription$onError$1.invoke(ObserveOnProcessor.java:37)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription$onError$1.invoke(ObserveOnProcessor.java:25)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.java:20)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchQueueKt.dispatch(DispatchQueueKt.java:15)
       at com.mirego.trikot.streams.reactive.processors.ObserveOnProcessor$ObserveOnProcessorSubscription.onError(ObserveOnProcessor.java:37)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onError(ProcessorSubscription.java:27)
       at com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor$SwitchMapProcessorSubscription.onError(SwitchMapProcessor.java:73)
       at com.mirego.trikot.streams.reactive.PublisherSubscription.dispatchError(PublisherSubscription.java:33)
       at com.mirego.trikot.streams.reactive.PublishSubjectImpl.dispatchErrorToSubscribers(PublishSubjectImpl.java:109)
       at com.mirego.trikot.streams.reactive.PublishSubjectImpl$error$1.invoke(PublishSubjectImpl.java:59)
       at com.mirego.trikot.streams.reactive.PublishSubjectImpl$error$1.invoke(PublishSubjectImpl.java:8)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.java:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.java:20)
       at com.mirego.trikot.streams.reactive.PublishSubjectImpl.setError(PublishSubjectImpl.java:49)
       at com.mirego.trikot.streams.reactive.executable.BaseExecutablePublisher.dispatchError(BaseExecutablePublisher.java:37)
       at com.mirego.trikot.http.requestPublisher.HttpRequestPublisher$internalRun$1$1$1.invoke(HttpRequestPublisher.java:43)
       at com.mirego.trikot.http.requestPublisher.HttpRequestPublisher$internalRun$1$1$1.invoke(HttpRequestPublisher.java:18)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.JvmDispatchQueue$dispatch$1.run(JvmDispatchQueue.java:11)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:923)
```
## How Has This Been Tested?
Not tested, race conditions are hard to test with unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
