### PR TITLE
Add Promise.create() initializer

### DIFF
--- a/documentation/PROMISES.md
+++ b/documentation/PROMISES.md
@@ -71,7 +71,7 @@ Returns a new Promise instance that is rejected with the given throwable. Shorth
 Promises can also be created form asynchronous requests that are not publishers, using the following initializer:
 
 #### `Promise.create(cancellableManager?) { resolve, reject -> ... }`
-Returns a new Promise instance that will resolve or reject depending on the provided execution block. The provided block should at least, at any point in time, call resolve() with the desired value or (reject) with the desired throwable. The promise will not settle untill the resolve() or reject() blocks have been called, of if the cancellableManager has been cancelled.
+Returns a new Promise instance that will resolve or reject depending on the provided execution block. The provided block should at least, at any point in time, call resolve() with the desired value or reject() with the desired throwable. The promise will not settle untill the resolve() or reject() blocks have been called, of if the cancellableManager has been cancelled.
 
 Using this initializer allows for a `CancellableManager` to be provided optionally.
 

--- a/documentation/PROMISES.md
+++ b/documentation/PROMISES.md
@@ -48,7 +48,7 @@ When the upstream *publisher* :
 4. emits a completed signal and did not emit any value or error
     - The Promise is rejected with a `EmptyPromiseException`
 
-Using this initializer allows for a `CancellableManager` to be provided optionnally.
+Using this initializer allows for a `CancellableManager` to be provided optionally.
 
 When the provided *cancellableManager* :
 1. Is cancelled **before** the Promise's creation
@@ -65,6 +65,25 @@ Returns a new Promise instance that is resolved with the given value. Shorthand 
 
 #### `Promise.reject(throwable)`
 Returns a new Promise instance that is rejected with the given throwable. Shorthand for `Promise.from(Publishers.error(value))`.
+
+## Creation (part 2.)
+
+Promises can also be created form asynchronous requests that are not publishers, using the following initializer:
+
+#### `Promise.create(cancellableManager?) { resolve, reject -> ... }`
+Returns a new Promise instance that will resolve or reject depending on the provided execution block. The provided block should at least, at any point in time, call resolve() with the desired value or (reject) with the desired throwable. The promise will not settle untill the resolve() or reject() blocks have been called, of if the cancellableManager has been cancelled.
+
+Using this initializer allows for a `CancellableManager` to be provided optionally.
+
+When the provided *cancellableManager* :
+1. Is cancelled **before** the Promise's creation
+    - The Promise is rejected with a `CancelledPromiseException`
+2. Is cancelled **after** the Promise's creation, but **before** the resolve() or reject() block have been called
+    - The Promise is rejected with a `CancelledPromiseException`
+3. Is cancelled **after** the Promise's creation, and **after** the resolve() or reject() block have been called
+    - The Promise is not affected and is settled as usual with the resolved value or rejected error.
+4. Is `null`
+    - The Promise is not affected and is settled as usual with the resolved value or rejected error
 
 ## Chaining 
 


### PR DESCRIPTION
## Description
This PR introduces support for creating Promises from asynchronous requests that are not Publishers.

## Motivation and Context
I've seen myself many times rewrite the same boilerplate code when creating a promise from an asynchronous result (other than a publisher). 

Here's a common example on Android apps :

```kotlin
private fun getAsyncStringFromService(): Promise<String> {
    val deferredResult = Publishers.behaviorSubject<String>()

    MyExternalService.instance().asyncString.addOnCompleteListener { task ->
        if (task.isSuccessful) {
            deferredResult.value = task.result
        } else {
            deferredResult.error = task.exception ?: Exception("Could not retrieve async string from service")
        }
    }

    return Promise.from(deferredResult)
}
```

Here's another common example :

```kotlin
private fun getAsyncObject(): Promise<MyObject> {
    val deferredResult = Publishers.behaviorSubject<MyObject>()

    DispatchQueue.BackgroundQueue.dispatch {
        val myObject: MyObject = heavyWorkToComputeNewObject()
        deferredResult.value = myObject
    }

    return Promise.from(deferredResult)
}
```

The goal here is to reduce the boilerplate code (the Publishers creation) and make it more fun to create promise from asynchronous results. 🙂 

🎉  Here's what it would look now : 

```kotlin
private fun getAsyncObject(): Promise<MyObject> {
    return Promise.create { resolve, reject ->
        DispatchQueue.BackgroundQueue.dispatch {
            val myObject: MyObject = heavyWorkToComputeNewObject()
            resolve(myObject)
        }
    }
}
```

## How Has This Been Tested?
This has not been tested in a multiplatform environment yet. It is simply unit tested for now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
