### PR TITLE
Skip(n) operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -5,7 +5,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class JustPublisher<T>(private val value: T) : Publisher<T> {
+class JustPublisher<T>(private val values: Array<out T>) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
         val isCancelled = AtomicReference(false)
         s.onSubscribe(
@@ -18,7 +18,9 @@ class JustPublisher<T>(private val value: T) : Publisher<T> {
             }
         )
         if (!isCancelled.value) {
-            s.onNext(value)
+            for (value in values) {
+                s.onNext(value)
+            }
         }
         if (!isCancelled.value) {
             s.onComplete()

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -24,6 +24,7 @@ import com.mirego.trikot.streams.reactive.processors.RetryWhenPublisherBlock
 import com.mirego.trikot.streams.reactive.processors.ScanProcessor
 import com.mirego.trikot.streams.reactive.processors.ScanProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.SharedProcessor
+import com.mirego.trikot.streams.reactive.processors.SkipProcessor
 import com.mirego.trikot.streams.reactive.processors.SubscribeOnProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessorBlock
@@ -190,3 +191,6 @@ fun <T> Publisher<T>.scan(block: ScanProcessorBlock<T>): Publisher<T> {
 fun <T> Publisher<T>.scan(initialValue: T, block: ScanProcessorBlock<T>): Publisher<T> {
     return ScanProcessor(this, initialValue, block)
 }
+
+/** Suppress the first n items emitted by a Publisher **/
+fun <T> Publisher<T>.skip(n: Long) = SkipProcessor(this, n)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -17,8 +17,8 @@ object Publishers {
      * Create a Publisher that emits a particular item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">http://reactivex.io/documentation/operators/just.html</a>
      */
-    fun <T> just(value: T): Publisher<T> {
-        return JustPublisher(value)
+    fun <T> just(vararg values: T): Publisher<T> {
+        return JustPublisher(values)
     }
 
     /**

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessor.kt
@@ -1,0 +1,24 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import kotlin.math.max
+
+class SkipProcessor<T>(parentPublisher: Publisher<T>, private val n: Long) : AbstractProcessor<T, T>(parentPublisher) {
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return SkipProcessorSubscription(subscriber, n)
+    }
+
+    class SkipProcessorSubscription<T>(s: Subscriber<in T>, n: Long) : ProcessorSubscription<T, T>(s) {
+        private val remaining = AtomicReference(max(0, n))
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            if (remaining.value != 0L) {
+                remaining.setOrThrow(remaining.value, remaining.value - 1)
+            } else {
+                subscriber.onNext(t)
+            }
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
@@ -2,6 +2,8 @@ package com.mirego.trikot.streams.reactive
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class JustPublisherTests {
 
@@ -16,7 +18,22 @@ class JustPublisherTests {
             onError = { throw IllegalStateException() },
             onCompleted = { completion = true }
         )
-        kotlin.test.assertEquals("VALUE", value)
-        kotlin.test.assertTrue(completion)
+        assertEquals("VALUE", value)
+        assertTrue(completion)
+    }
+
+    @Test
+    fun justPublisherEmitMultipleNextAndCompletion() {
+        val publisher = Publishers.just("VALUE1", "VALUE2")
+        val values = mutableListOf<String>()
+        var completion = false
+        publisher.subscribe(
+            CancellableManager(),
+            onNext = { values += it },
+            onError = { throw IllegalStateException() },
+            onCompleted = { completion = true }
+        )
+        assertEquals(listOf("VALUE1", "VALUE2"), values)
+        assertTrue(completion)
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
@@ -1,0 +1,125 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.skip
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkipProcessorTests {
+    @Test
+    fun skipNegativeElements() {
+        val values = mutableListOf<String>()
+        var completed = false
+
+        Publishers.just("a", "b", "c")
+            .skip(-99)
+            .subscribe(
+                CancellableManager(),
+                onNext = { values += it },
+                onError = {},
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf("a", "b", "c"), values)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun skipZeroElements() {
+        val values = mutableListOf<String>()
+        var completed = false
+
+        Publishers.just("a", "b", "c")
+            .skip(0)
+            .subscribe(
+                CancellableManager(),
+                onNext = { values += it },
+                onError = {},
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf("a", "b", "c"), values)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun skipOneElements() {
+        val values = mutableListOf<String>()
+        var completed = false
+
+        Publishers.just("a", "b", "c")
+            .skip(1)
+            .subscribe(
+                CancellableManager(),
+                onNext = { values += it },
+                onError = {},
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf("b", "c"), values)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun skipTwoElements() {
+        val values = mutableListOf<String>()
+        var completed = false
+
+        Publishers.just("a", "b", "c")
+            .skip(2)
+            .subscribe(
+                CancellableManager(),
+                onNext = { values += it },
+                onError = {},
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf("c"), values)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun skipThreeElements() {
+        val values = mutableListOf<String>()
+        var completed = false
+
+        Publishers.just("a", "b", "c")
+            .skip(3)
+            .subscribe(
+                CancellableManager(),
+                onNext = { values += it },
+                onError = {},
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf<String>(), values)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun skipMultipleSubscriptions() {
+        val values1 = mutableListOf<String>()
+        val values2 = mutableListOf<String>()
+
+        val skipPublisher = Publishers.just("a", "b", "c")
+            .skip(2)
+
+        skipPublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = { values1 += it }
+            )
+
+        skipPublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = { values2 += it }
+            )
+
+        assertEquals(listOf("c"), values1)
+        assertEquals(listOf("c"), values2)
+    }
+}


### PR DESCRIPTION
## Description
This implements skip(n) operator
This also changes the just publisher to a vararg so we can emit more than one value

<img width="756" alt="Screen Shot 2021-02-05 at 3 45 04 PM" src="https://user-images.githubusercontent.com/618592/107087392-5d84be00-67c9-11eb-803a-5b01c13f13f2.png">

## Motivation and Context
Basic skip operator was missing! just with vararg can be useful in tests too.

## How Has This Been Tested?
Unit tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
