### PR TITLE
Just binary compatibility

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -5,7 +5,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class JustPublisher<T>(private val values: Array<out T>) : Publisher<T> {
+class JustPublisher<T>(private val values: List<T>) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
         val isCancelled = AtomicReference(false)
         s.onSubscribe(

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -20,11 +20,10 @@ object Publishers {
     fun <T> just(value: T): Publisher<T> {
         return JustPublisher(listOf(value))
     }
-    
+
     fun <T> justMany(vararg values: T): Publisher<T> {
         return JustPublisher(values.toList())
     }
-    
 
     /**
      * Create a Publisher that emits no items but terminates normally

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -17,9 +17,14 @@ object Publishers {
      * Create a Publisher that emits a particular item
      * @see <a href="http://reactivex.io/documentation/operators/just.html">http://reactivex.io/documentation/operators/just.html</a>
      */
-    fun <T> just(vararg values: T): Publisher<T> {
-        return JustPublisher(values)
+    fun <T> just(value: T): Publisher<T> {
+        return JustPublisher(listOf(value))
     }
+    
+    fun <T> justMany(vararg values: T): Publisher<T> {
+        return JustPublisher(values.toList())
+    }
+    
 
     /**
      * Create a Publisher that emits no items but terminates normally

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/JustPublisherTests.kt
@@ -24,7 +24,7 @@ class JustPublisherTests {
 
     @Test
     fun justPublisherEmitMultipleNextAndCompletion() {
-        val publisher = Publishers.just("VALUE1", "VALUE2")
+        val publisher = Publishers.justMany("VALUE1", "VALUE2")
         val values = mutableListOf<String>()
         var completion = false
         publisher.subscribe(

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
@@ -50,7 +50,7 @@ class SkipProcessorTests {
         val values = mutableListOf<String>()
         var completed = false
 
-        Publishers.just("a", "b", "c")
+        Publishers.justMany("a", "b", "c")
             .skip(1)
             .subscribe(
                 CancellableManager(),
@@ -68,7 +68,7 @@ class SkipProcessorTests {
         val values = mutableListOf<String>()
         var completed = false
 
-        Publishers.just("a", "b", "c")
+        Publishers.justMany("a", "b", "c")
             .skip(2)
             .subscribe(
                 CancellableManager(),
@@ -86,7 +86,7 @@ class SkipProcessorTests {
         val values = mutableListOf<String>()
         var completed = false
 
-        Publishers.just("a", "b", "c")
+        Publishers.justMany("a", "b", "c")
             .skip(3)
             .subscribe(
                 CancellableManager(),
@@ -104,7 +104,7 @@ class SkipProcessorTests {
         val values1 = mutableListOf<String>()
         val values2 = mutableListOf<String>()
 
-        val skipPublisher = Publishers.just("a", "b", "c")
+        val skipPublisher = Publishers.justMany("a", "b", "c")
             .skip(2)
 
         skipPublisher

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SkipProcessorTests.kt
@@ -14,7 +14,7 @@ class SkipProcessorTests {
         val values = mutableListOf<String>()
         var completed = false
 
-        Publishers.just("a", "b", "c")
+        Publishers.justMany("a", "b", "c")
             .skip(-99)
             .subscribe(
                 CancellableManager(),
@@ -32,7 +32,7 @@ class SkipProcessorTests {
         val values = mutableListOf<String>()
         var completed = false
 
-        Publishers.just("a", "b", "c")
+        Publishers.justMany("a", "b", "c")
             .skip(0)
             .subscribe(
                 CancellableManager(),


### PR DESCRIPTION
## Description
Preserve binary compatiblity with just, we rename the vararg one to justMany so they won't clash.
PR that broke binary compatibility: https://github.com/mirego/trikot.streams/pull/89

## Motivation and Context
There was an issue with binary compatibility of other libs using trikot.streams previous version that wouldn't work with the new version unless updated. I prefered to keep binary compat by renaming it.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
