### PR TITLE
Support Publisher.delay() operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -5,7 +5,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class JustPublisher<T>(private val values: List<T>) : Publisher<T> {
+class JustPublisher<T>(private val values: Iterable<T>) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
         val isCancelled = AtomicReference(false)
         s.onSubscribe(

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -7,6 +7,7 @@ import com.mirego.trikot.streams.StreamsConfiguration
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.processors.ConcatProcessor
 import com.mirego.trikot.streams.reactive.processors.DebounceProcessor
+import com.mirego.trikot.streams.reactive.processors.DelayProcessor
 import com.mirego.trikot.streams.reactive.processors.DistinctUntilChangedProcessor
 import com.mirego.trikot.streams.reactive.processors.FilterProcessor
 import com.mirego.trikot.streams.reactive.processors.FilterProcessorBlock
@@ -136,6 +137,29 @@ fun <T> Publisher<T>.timeout(
     return TimeoutProcessor(duration = duration, timeoutMessage = message, parentPublisher = this)
 }
 
+/**
+ * Shift the emissions from the Publisher forward in time by the specified duration
+ *
+ * The Delay operator modifies its source Publisher by pausing for a particular increment of time
+ * (that you specify) before emitting each of the source Publisher’s items. This has the effect of
+ * shifting the entire sequence of items emitted by the Publisher forward in time by that
+ * specified increment.
+ *
+ * Marbles diagram :
+ * -------(1)---(2)-------(3)--------(4)---|->
+ * delay()
+ * ----------------(1)---(2)-------(3)-----|->
+ *
+ * @see @see <a href="http://reactivex.io/documentation/operators/delay.html">http://reactivex.io/documentation/operators/delay.html</a>
+ */
+@ExperimentalTime
+fun <T> Publisher<T>.delay(
+    duration: Duration,
+    timerFactory: TimerFactory = FoundationConfiguration.timerFactory
+): Publisher<T> {
+    return DelayProcessor(this, duration, timerFactory)
+}
+
 @ExperimentalTime
 fun <T> Publisher<T>.debounce(
     timeout: Duration,
@@ -144,7 +168,7 @@ fun <T> Publisher<T>.debounce(
     return DebounceProcessor(this, timeout, timerFactory)
 }
 
-/**+
+/**
  * Returns a Publisher that mirrors the source Publisher with the exception of an error.
  * If the source Publisher calls error, this method will emit the Throwable that caused the error to the Publisher returned from notifier.
  * If that Publisher calls complete or error then this method will call complete or error on the child subscription.

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -26,6 +26,14 @@ object Publishers {
     }
 
     /**
+     * Create a Publisher that emits the provided iterable sequence of items
+     * @see <a href="http://reactivex.io/documentation/operators/from.html">http://reactivex.io/documentation/operators/from.html</a>
+     */
+    fun <T> fromIterable(iterable: Iterable<T>): Publisher<T> {
+        return JustPublisher(iterable)
+    }
+
+    /**
      * Create a Publisher that emits no items but terminates normally
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
      */

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessor.kt
@@ -1,0 +1,45 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.timers.TimerFactory
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+class DelayProcessor<T>(
+    parentPublisher: Publisher<T>,
+    private val duration: Duration,
+    private val timerFactory: TimerFactory
+) : AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return DelayProcessorSubscription(subscriber, duration, timerFactory)
+    }
+
+    class DelayProcessorSubscription<T>(
+        subscriber: Subscriber<in T>,
+        private val delay: Duration,
+        private val timerFactory: TimerFactory
+    ) : ProcessorSubscription<T, T>(subscriber) {
+
+        private val cancellableManagerProvider = CancellableManager()
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            val timer = timerFactory.single(delay) { subscriber.onNext(t) }
+            cancellableManagerProvider.add { timer.cancel() }
+        }
+
+        override fun onCancel(s: Subscription) {
+            super.onCancel(s)
+            cancellableManagerProvider.cancel()
+        }
+
+        override fun onComplete() {
+            super.onComplete()
+            cancellableManagerProvider.cancel()
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessorTests.kt
@@ -79,13 +79,18 @@ class DelayProcessorTests {
         var completed = false
         publisher
             .delay(5.seconds, timerFactory)
-            .subscribe(CancellableManager(), onNext = {
-                receivedResults.add(it)
-            }, onError = {
-                error = it
-            }, onCompleted = {
-                completed = true
-            })
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                    error = it
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
 
         publisher.value = "a"
         timers[0].executeBlock()

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DelayProcessorTests.kt
@@ -1,0 +1,107 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.delay
+import com.mirego.trikot.streams.reactive.subscribe
+import com.mirego.trikot.streams.utils.MockTimer
+import com.mirego.trikot.streams.utils.MockTimerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
+
+@ExperimentalTime
+class DelayProcessorTests {
+
+    @Test
+    fun testEveryUpstreamValueIsDelayedByTheSameAmountOfTime() {
+        val values = listOf("a", "b", "c")
+        val publisher = Publishers.fromIterable(values)
+
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, _ -> MockTimer().also { timers.add(it) } }
+
+        val receivedResults = mutableListOf<String>()
+        publisher
+            .delay(5.seconds, timerFactory)
+            .subscribe(CancellableManager()) {
+                receivedResults.add(it)
+            }
+
+        timers.forEachIndexed { index, mockTimer ->
+            mockTimer.executeBlock()
+            assertEquals(values[index], receivedResults[index])
+        }
+
+        assertEquals(values.size, timerFactory.singleCall)
+    }
+
+    @Test
+    fun testTimersAreCancelledWhenSubscriptionIsCancelled() {
+        val values = listOf("a", "b", "c")
+        val publisher = Publishers.fromIterable(values)
+
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, _ -> MockTimer().also { timers.add(it) } }
+
+        val cancellableManager = CancellableManager()
+        val receivedResults = mutableListOf<String>()
+        publisher
+            .delay(5.seconds, timerFactory)
+            .subscribe(cancellableManager) {
+                receivedResults.add(it)
+            }
+
+        timers.forEachIndexed { index, mockTimer ->
+            mockTimer.executeBlock()
+
+            if (index == 1) { // Cancel subscription after second element "b" is received
+                cancellableManager.cancel()
+            }
+        }
+
+        assertEquals(listOf("a", "b"), receivedResults)
+        timers.forEach { assertTrue(it.isCancelled) }
+    }
+
+    @Test
+    fun testTimersAreCancelledWhenUpstreamCompletesBeforeTimersCompletion() {
+        val publisher = Publishers.behaviorSubject<String>()
+
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, _ -> MockTimer().also { timers.add(it) } }
+
+        val receivedResults = mutableListOf<String>()
+        var error: Throwable? = null
+        var completed = false
+        publisher
+            .delay(5.seconds, timerFactory)
+            .subscribe(CancellableManager(), onNext = {
+                receivedResults.add(it)
+            }, onError = {
+                error = it
+            }, onCompleted = {
+                completed = true
+            })
+
+        publisher.value = "a"
+        timers[0].executeBlock()
+        assertEquals(listOf("a"), receivedResults)
+
+        publisher.value = "b"
+        timers[1].executeBlock()
+        assertEquals(listOf("a", "b"), receivedResults)
+
+        publisher.value = "c"
+        // delayed timer does not fire yet!
+        publisher.complete()
+
+        assertEquals(listOf("a", "b"), receivedResults)
+        assertNull(error)
+        assertTrue(completed)
+        assertTrue(timers[2].isCancelled)
+    }
+}


### PR DESCRIPTION
## Description
The Delay operator modifies its source Publisher by pausing for a particular increment of time (that you specify) before emitting each of the source Publisher’s items. This has the effect of shifting the entire sequence of items emitted by the Publisher forward in time by that specified increment.

## Motivation and Context
This operator is missing from our Publisher feature set.

## How Has This Been Tested?
This is fully unit tested, but has not been tested in a multiplatform environment yet.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
