### PR TITLE
Introduce Publishers.range()

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -34,6 +34,14 @@ object Publishers {
     }
 
     /**
+     * Create a Publisher that emits a particular range of sequential integers
+     * @see <a href="http://reactivex.io/documentation/operators/range.html">http://reactivex.io/documentation/operators/range.html</a>
+     */
+    fun range(start: Int, endInclusive: Int): Publisher<Int> {
+        return JustPublisher(start..endInclusive)
+    }
+
+    /**
      * Create a Publisher that emits no items but terminates normally
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
      */

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/RangePublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/RangePublisherTests.kt
@@ -1,0 +1,30 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RangePublisherTests {
+
+    @Test
+    fun rangePublisherEmitsAllValuesThenCompletes() {
+        val publisher = Publishers.range(1, 5)
+
+        val values = mutableListOf<Int>()
+        var error: Throwable? = null
+        var completed = false
+
+        publisher.subscribe(
+            CancellableManager(),
+            onNext = { values += it },
+            onError = { error = it },
+            onCompleted = { completed = true }
+        )
+
+        assertEquals(listOf(1, 2, 3, 4, 5), values)
+        assertNull(error)
+        assertTrue(completed)
+    }
+}


### PR DESCRIPTION
## Description
This allows us to easily create a Publisher that emits a particular range of sequential integers

## How Has This Been Tested?
This is unit tested, bu has not been tested in a multiplatform enviroment yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
