### PR TITLE
Update pull request template to include #dispatch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,20 @@
-<!--- Provide a general summary of your changes in the Title above -->
+## 📖 Description
+<!--- What types of changes does your code introduce? Uncomment all options that apply: -->
+<!-- 🐛 Bug fix (non-breaking change which fixes an issue) -->
+<!-- 🧠 New feature (non-breaking change which adds functionality) -->
+<!-- 💔 Breaking change (fix or feature that would cause existing functionality to change) -->
 
-## Description
 <!--- Describe your changes in detail -->
 
-## Motivation and Context
-<!--- Why is those changes required? What problem does it solve? -->
+## 💭 Motivation and Context
+<!--- Why are those changes required? What problem(s) does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
 
-## How Has This Been Tested?
+## 🧪 How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
-## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+## 🦀 Dispatch
+<!--- If needed, please specify the dispatch stack for which to suggest appropriate reviewers. -->
+- `#dispatch/kmp`


### PR DESCRIPTION
Emojis were added and the "Type of changes" section has been moved to the description part. 

Also, the "Type of changes" checkboxes were removed to avoir seeing "[1/3 tasks]" (as if the PR was incomplete) in the pull-requests page.