### PR TITLE
ConcretePublisher allows generic value of the publisher to be available in Swift code

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ConcretePublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ConcretePublisher.kt
@@ -1,0 +1,12 @@
+package com.mirego.trikot.streams.reactive
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+fun <T> Publisher<T>.asConcretePublisher(): ConcretePublisher<T> = ConcretePublisher(this)
+
+class ConcretePublisher<T>(private val publisher: Publisher<T>) : Publisher<T> {
+    override fun subscribe(s: Subscriber<in T>) {
+        publisher.subscribe(s)
+    }
+}


### PR DESCRIPTION
## Description
When a Kotlin interface with a generic type is used in Swift, the generic value is lost. But if a class has a generic type, the type will be available in Swift.

With the "ConcretePublisher" you can easily expose a publisher in a class to keep the generic value in Swift.

Credits: @antoinelamy ©2020

## Motivation and Context
To have the generic type in publisher in Swift code.

## How Has This Been Tested?
In my project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
