### PR TITLE
Excluded transitive dependencies on "org.reactivestreams" to avoid duplicate classes on Android

### DIFF
--- a/streams/build.gradle.kts
+++ b/streams/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
             dependsOn(commonMain)
             dependencies {
                 implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0"){
+                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0") {
                     exclude(group = "org.reactivestreams")
                 }
             }

--- a/streams/build.gradle.kts
+++ b/streams/build.gradle.kts
@@ -74,7 +74,9 @@ kotlin {
             dependsOn(commonMain)
             dependencies {
                 implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0")
+                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0"){
+                    exclude(group = "org.reactivestreams")
+                }
             }
         }
 


### PR DESCRIPTION
## Description
During the merge of android-ktx and main component, the exclusion of the transitive dependency on "org:reactivestreams" was lost. This resulted in build errors caused by the reactivestreams classes being included twice. (the Trikot ones and the "real" ones).

## Motivation and Context
Build errors.

## How Has This Been Tested?
In a a project using 2.0.0.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
