### PR TITLE
Update native binding to use just value when possible

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ConcretePublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/ConcretePublisher.kt
@@ -5,7 +5,7 @@ import org.reactivestreams.Subscriber
 
 fun <T> Publisher<T>.asConcretePublisher(): ConcretePublisher<T> = ConcretePublisher(this)
 
-class ConcretePublisher<T>(private val publisher: Publisher<T>) : Publisher<T> {
+class ConcretePublisher<T>(val publisher: Publisher<T>) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
         publisher.subscribe(s)
     }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/JustPublisher.kt
@@ -5,7 +5,7 @@ import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-class JustPublisher<T>(private val values: Iterable<T>) : Publisher<T> {
+class JustPublisher<T>(val values: Iterable<T>) : Publisher<T> {
     override fun subscribe(s: Subscriber<in T>) {
         val isCancelled = AtomicReference(false)
         s.onSubscribe(

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/NeverPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/NeverPublisher.kt
@@ -1,0 +1,18 @@
+package com.mirego.trikot.streams.reactive
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+class NeverPublisher<T> : Publisher<T> {
+    override fun subscribe(s: Subscriber<in T>) {
+        s.onSubscribe(
+            object : Subscription {
+                override fun request(n: Long) {}
+
+                override fun cancel() {
+                }
+            }
+        )
+    }
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,8 +1,6 @@
 package com.mirego.trikot.streams.reactive
 
 import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
 
 object Publishers {
     fun <T> behaviorSubject(value: T? = null): BehaviorSubject<T> {
@@ -54,19 +52,7 @@ object Publishers {
      * @see <a href="http://reactivex.io/documentation/operators/empty-never-throw.html">http://reactivex.io/documentation/operators/empty-never-throw.html</a>
      */
     fun <T> never(): Publisher<T> {
-        return object : Publisher<T> {
-            override fun subscribe(s: Subscriber<in T>) {
-                s.onSubscribe(
-                    object : Subscription {
-                        override fun request(n: Long) {
-                        }
-
-                        override fun cancel() {
-                        }
-                    }
-                )
-            }
-        }
+        return NeverPublisher()
     }
 
     /**


### PR DESCRIPTION
## Description
Optimize JustPublisher subscription.

## Motivation and Context
Creating Subscription bag and internal JustPublisher subscription takes a lot of CPU time. This PR bypass the subscription to the JustPublisher by checking the type and returning the value synchronously. 

## How Has This Been Tested?
- Not yet tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
