### PR TITLE
Make debounce processor emit value when completed

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/DebounceProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/DebounceProcessor.kt
@@ -1,6 +1,9 @@
 package com.mirego.trikot.streams.reactive.processors
 
 import com.mirego.trikot.foundation.FoundationConfiguration
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import com.mirego.trikot.foundation.concurrent.setOrThrow
 import com.mirego.trikot.foundation.timers.TimerFactory
 import com.mirego.trikot.streams.cancellable.CancellableManagerProvider
 import org.reactivestreams.Publisher
@@ -21,15 +24,26 @@ class DebounceProcessor<T>(
     }
 
     class DebounceProcessorSubscription<T>(
-        subscriber: Subscriber<in T>,
+        private val subscriber: Subscriber<in T>,
         private val timeout: Duration,
         private val timerFactory: TimerFactory = FoundationConfiguration.timerFactory
     ) : ProcessorSubscription<T, T>(subscriber) {
         private val cancellableManagerProvider = CancellableManagerProvider()
+        private val valueToDispatch = AtomicReference<T?>(null)
+        private val isCancelledOrCompleted = AtomicReference<Boolean>(false)
+        private val serialQueue = SynchronousSerialQueue()
 
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             cancellableManagerProvider.cancelPreviousAndCreate().also { cancellableManager ->
-                timerFactory.single(timeout) { subscriber.onNext(t) }.also {
+                valueToDispatch.setOrThrow(t)
+                timerFactory.single(timeout) {
+                    serialQueue.dispatch {
+                        if (!isCancelledOrCompleted.value) {
+                            valueToDispatch.compareAndSet(t, null)
+                            subscriber.onNext(t)
+                        }
+                    }
+                }.also {
                     cancellableManager.add { it.cancel() }
                 }
             }
@@ -37,7 +51,27 @@ class DebounceProcessor<T>(
 
         override fun onCancel(s: Subscription) {
             super.onCancel(s)
-            cancellableManagerProvider.cancelPreviousAndCreate()
+            isCancelledOrCompleted.setOrThrow(true)
+            cancellableManagerProvider.cancel()
+        }
+
+        override fun onError(t: Throwable) {
+            isCancelledOrCompleted.setOrThrow(true)
+            cancellableManagerProvider.cancel()
+            serialQueue.dispatch {
+                super.onError(t)
+            }
+        }
+
+        override fun onComplete() {
+            isCancelledOrCompleted.setOrThrow(true)
+            serialQueue.dispatch {
+                valueToDispatch.value?.let {
+                    subscriber.onNext(it)
+                }
+                super.onComplete()
+                cancellableManagerProvider.cancel()
+            }
         }
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DebounceProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/DebounceProcessorTests.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
+import kotlin.time.minutes
 
 @ExperimentalTime
 class DebounceProcessorTests {
@@ -47,5 +48,21 @@ class DebounceProcessorTests {
         publisher.value = expectedResult
         assertEquals(null, receivedResult)
         assertEquals(noBlock, timer.block)
+    }
+
+    @Test
+    fun testDebounceCompleted() {
+        val expectedResult = "b"
+        val publisher = Publishers.behaviorSubject(expectedResult)
+        val timer = MockTimer()
+        var receivedResult: String? = null
+        publisher
+            .debounce(600.minutes, MockTimerFactory { _, _ -> timer })
+            .subscribe(CancellableManager()) {
+                receivedResult = it
+            }
+        publisher.value = expectedResult
+        publisher.complete()
+        assertEquals(expectedResult, receivedResult)
     }
 }


### PR DESCRIPTION
## 📖 Description
🐛 Bug fix + 💔 Breaking change

Make Debounce processor emit last received value when completing and value was not sent yet.

## 💭 Motivation and Context
Actual behaviour did not emit the last received value when receiving completed and the timer hasn't triggered yet.

The old behaviour
- Could cause crash as if cancel (unSubscription) was received asynchronously, debounce processor would break the contract and send a value after the onNext (Would result in crashs)
- Could Ignore last received value 

## 🧪 How Has This Been Tested?
See DebounceProcessorTests

## 🦀 Dispatch
- `#dispatch/kmp`
