### PR TITLE
Add factory method for directly frozen subjects

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.streams.reactive
 
+import com.mirego.trikot.foundation.concurrent.MrFreeze
 import org.reactivestreams.Publisher
 
 object Publishers {
@@ -7,8 +8,16 @@ object Publishers {
         return BehaviorSubjectImpl(value)
     }
 
+    fun <T> frozenBehaviorSubject(value: T? = null): BehaviorSubject<T> {
+        return MrFreeze.freeze(BehaviorSubjectImpl(value))
+    }
+
     fun <T> publishSubject(): PublishSubject<T> {
         return PublishSubjectImpl()
+    }
+
+    fun <T> frozenPublishSubject(): PublishSubject<T> {
+        return MrFreeze.freeze(PublishSubjectImpl())
     }
 
     /**

--- a/streams/src/iosX64Test/kotlin/com/FrozenPublisherTests.kt
+++ b/streams/src/iosX64Test/kotlin/com/FrozenPublisherTests.kt
@@ -1,0 +1,21 @@
+package com
+
+import com.mirego.trikot.streams.reactive.Publishers
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FrozenPublisherTests {
+
+    @Test
+    fun `Publishers.frozenBehaviourSubjects really returns a frozen publisher`() {
+        val publisher = Publishers.frozenBehaviorSubject("test")
+        assertTrue(publisher.isFrozen)
+    }
+
+    @Test
+    fun `Publishers.frozenPublishSubjects really returns a frozen publisher`() {
+        val publisher = Publishers.frozenPublishSubject<String>()
+        assertTrue(publisher.isFrozen)
+    }
+}

--- a/streams/src/iosX64Test/kotlin/com/ThreadLocalProcessorTests.kt
+++ b/streams/src/iosX64Test/kotlin/com/ThreadLocalProcessorTests.kt
@@ -19,8 +19,7 @@ class ThreadLocalProcessorTests {
 
     @Test
     fun threadLocalSubscribersAreNotFrozenByFrozenParentPublisher() {
-        val initialPublisher = Publishers.behaviorSubject("a")
-        initialPublisher.freeze()
+        val initialPublisher = Publishers.frozenBehaviorSubject("a")
         val threadLocal =
             ThreadLocalProcessor(initialPublisher, FreezingDispatchQueue(), FreezingDispatchQueue())
         val sharedPublisher = threadLocal.shared().also { MrFreeze.ensureNeverFrozen(it) }


### PR DESCRIPTION
## 📖 Description
🧠 New feature (non-breaking change which adds functionality)

Add 2 factory methods on `Publishers` to get already frozen instances of `BehaviourSubject` and `PublishSubject`

## 💭 Motivation and Context
When used on the native side, we almost always want to use frozen subjects since we are going to pass them into the common code. Receiving an already frozen Behaviour or Publish subject. Will help prevent race condition crashes since freezing an object is not thread safe.

This change will be used to fix one such race condition in trikot.http

## 🧪 How Has This Been Tested?
Unit tests added

## 🦀 Dispatch
#dispatch/kmp
