### PR TITLE
Publishers.timer(duration)

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,7 +1,10 @@
 package com.mirego.trikot.streams.reactive
 
+import com.mirego.trikot.foundation.FoundationConfiguration
 import com.mirego.trikot.foundation.concurrent.MrFreeze
+import com.mirego.trikot.foundation.timers.TimerFactory
 import org.reactivestreams.Publisher
+import kotlin.time.Duration
 
 object Publishers {
     fun <T> behaviorSubject(value: T? = null): BehaviorSubject<T> {
@@ -76,6 +79,15 @@ object Publishers {
     fun <T> completed(): Publisher<T> {
         return publishSubject<T>().also { it.complete() }
     }
+
+    /**
+     * Create a Publisher that emits after delay and terminates.
+     */
+    fun timer(
+        delay: Duration,
+        timerFactory: TimerFactory = FoundationConfiguration.timerFactory
+    ): Publisher<Long> =
+        TimerPublisher(delay, timerFactory)
 }
 
 fun <T> T.asPublisher(): Publisher<T> = Publishers.behaviorSubject(this)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/TimerPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/TimerPublisher.kt
@@ -23,7 +23,7 @@ class TimerPublisher(
 
     private class TimerSubscription(
         private val downstream: Subscriber<in Long>
-    ): Subscription {
+    ) : Subscription {
 
         val timerRef = AtomicReference<Timer?>(null)
         private var cancelled by atomic(false)
@@ -47,6 +47,5 @@ class TimerPublisher(
                 cancelled = true
             }
         }
-
     }
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/TimerPublisher.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/TimerPublisher.kt
@@ -1,0 +1,52 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.foundation.concurrent.setOrThrow
+import com.mirego.trikot.foundation.timers.Timer
+import com.mirego.trikot.foundation.timers.TimerFactory
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import kotlin.time.Duration
+
+class TimerPublisher(
+    private val delay: Duration,
+    private val timerFactory: TimerFactory
+) : Publisher<Long> {
+    override fun subscribe(s: Subscriber<in Long>) {
+        val timerSubscription = TimerSubscription(s)
+        s.onSubscribe(timerSubscription)
+        val timer = timerFactory.single(delay, timerSubscription::timerReached)
+        timerSubscription.timerRef.setOrThrow(timer)
+    }
+
+    private class TimerSubscription(
+        private val downstream: Subscriber<in Long>
+    ): Subscription {
+
+        val timerRef = AtomicReference<Timer?>(null)
+        private var cancelled by atomic(false)
+
+        fun timerReached() {
+            if (!cancelled) {
+                downstream.onNext(0L)
+                timerRef.compareAndSet(timerRef.value, null)
+                downstream.onComplete()
+            }
+        }
+
+        override fun request(n: Long) {
+            // NO-OP
+        }
+
+        override fun cancel() {
+            val timer = timerRef.value
+            if (timer != null && timerRef.compareAndSet(timer, null)) {
+                timer.cancel()
+                cancelled = true
+            }
+        }
+
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/TimerPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/TimerPublisherTests.kt
@@ -36,7 +36,8 @@ class TimerPublisherTests {
                 CancellableManager(),
                 onNext = { receivedResults.add(it) },
                 onError = {},
-                onCompleted = { completed = true })
+                onCompleted = { completed = true }
+            )
 
         assertEquals(1, timerFactory.singleCall)
         timers[0].executeBlock()
@@ -62,7 +63,8 @@ class TimerPublisherTests {
                 cancellableManager,
                 onNext = { receivedResults.add(it) },
                 onError = {},
-                onCompleted = { completed = true })
+                onCompleted = { completed = true }
+            )
 
         assertEquals(1, timerFactory.singleCall)
 

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/TimerPublisherTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/TimerPublisherTests.kt
@@ -1,0 +1,76 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.utils.MockTimer
+import com.mirego.trikot.streams.utils.MockTimerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.seconds
+
+class TimerPublisherTests {
+
+    @Test
+    fun testTimerPublisher_doesNothingIfNotSubscribed() {
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, _ -> MockTimer().also { timers.add(it) } }
+
+        Publishers.timer(10.seconds, timerFactory)
+        assertEquals(0, timerFactory.singleCall)
+    }
+
+    @Test
+    fun testTimerPublisher_emitsAfterSubscriptionDelay() {
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, duration ->
+            assertEquals(10.seconds, duration)
+            MockTimer().also { timers.add(it) }
+        }
+        val timerPublisher = Publishers.timer(10.seconds, timerFactory)
+
+        val receivedResults = mutableListOf<Long>()
+        var completed = false
+        timerPublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = { receivedResults.add(it) },
+                onError = {},
+                onCompleted = { completed = true })
+
+        assertEquals(1, timerFactory.singleCall)
+        timers[0].executeBlock()
+
+        assertEquals(listOf(0L), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testTimerPublisher_doesNotEmitIfCancelledBeforeDelay() {
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, duration ->
+            assertEquals(10.seconds, duration)
+            MockTimer().also { timers.add(it) }
+        }
+        val timerPublisher = Publishers.timer(10.seconds, timerFactory)
+
+        val receivedResults = mutableListOf<Long>()
+        var completed = false
+        val cancellableManager = CancellableManager()
+        timerPublisher
+            .subscribe(
+                cancellableManager,
+                onNext = { receivedResults.add(it) },
+                onError = {},
+                onCompleted = { completed = true })
+
+        assertEquals(1, timerFactory.singleCall)
+
+        cancellableManager.cancel()
+
+        timers[0].executeBlock()
+
+        assertEquals(emptyList(), receivedResults)
+        assertFalse(completed)
+    }
+}


### PR DESCRIPTION
## 📖 Description
Based on Rx Spec http://reactivex.io/documentation/operators/timer.html
This publisher emits a value after given delay and terminates. The delay starts on subscribe.

## 💭 Motivation and Context
I want to introduce a retryWhen processor that retries with an exponential backoff, this building block as missing.

## 🧪 How Has This Been Tested?
Unit tested

## 🦀 Dispatch
#dispatch/kmp
