### PR TITLE
Exponential backoff policy + Publisher.retryBackoff

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/backoff/BackoffPolicy.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/backoff/BackoffPolicy.kt
@@ -1,0 +1,13 @@
+package com.mirego.trikot.streams.reactive.backoff
+
+import kotlin.time.Duration
+
+sealed class Backoff {
+    object Stop : Backoff()
+    data class Next(val duration: Duration) : Backoff()
+}
+
+interface BackoffPolicy {
+    fun reset()
+    fun nextBackoff(): Backoff
+}

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/backoff/ExponentialBackoffPolicy.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/backoff/ExponentialBackoffPolicy.kt
@@ -1,0 +1,33 @@
+package com.mirego.trikot.streams.reactive.backoff
+
+import com.mirego.trikot.foundation.concurrent.atomic
+import kotlin.time.Duration
+import kotlin.time.milliseconds
+import kotlin.time.minutes
+
+private fun min(a: Duration, b: Duration): Duration {
+    return if (a <= b) a else b
+}
+
+class ExponentialBackoffPolicy(
+    private val initialInterval: Duration = 500.milliseconds,
+    private val maxRetries: Int? = null,
+    private val maxInterval: Duration = 1.minutes,
+    private val multiplier: Double = 1.5
+) : BackoffPolicy {
+    private var currentInterval: Duration by atomic(initialInterval)
+    private var currentIteration: Int by atomic(0)
+
+    override fun reset() {
+        currentInterval = initialInterval
+        currentIteration = 0
+    }
+
+    override fun nextBackoff(): Backoff {
+        if (currentIteration == maxRetries) return Backoff.Stop
+        val backoff = Backoff.Next(currentInterval)
+        currentIteration++
+        currentInterval = min(currentInterval * multiplier, maxInterval)
+        return backoff
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/RetryBackoffTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/RetryBackoffTests.kt
@@ -1,0 +1,164 @@
+package com.mirego.trikot.streams.reactive
+
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.backoff.ExponentialBackoffPolicy
+import com.mirego.trikot.streams.utils.MockTimer
+import com.mirego.trikot.streams.utils.MockTimerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.hours
+import kotlin.time.minutes
+import kotlin.time.seconds
+
+class RetryBackoffTests {
+    @Test
+    fun retryBackoff_successAfterFirstRetry() {
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, duration ->
+            assertEquals(1.minutes, duration)
+            MockTimer().also { timers.add(it) }
+        }
+        var attempt: Int by atomic(0)
+        val upStreamPublisher = ColdPublisher {
+            val result = when (val value = attempt) {
+                0 -> Publishers.error(Throwable())
+                else -> value.just()
+            }
+            attempt = attempt + 1
+            result
+        }
+        val retryPublisher = upStreamPublisher.retryBackoff(
+            ExponentialBackoffPolicy(
+                initialInterval = 1.minutes,
+                maxRetries = 8,
+                maxInterval = 1.hours,
+                multiplier = 2.0
+            ),
+            timerFactory
+        )
+        val receivedResults = mutableListOf<Int>()
+        val receivedErrors = mutableListOf<Throwable>()
+        retryPublisher.subscribe(
+            CancellableManager(),
+            onNext = { receivedResults.add(it) },
+            onError = { receivedErrors.add(it) },
+            onCompleted = {}
+        )
+
+        assertEquals(1, timerFactory.singleCall)
+        timers[0].executeBlock()
+        assertEquals(listOf(1), receivedResults)
+        assertEquals(emptyList(), receivedErrors)
+    }
+
+    @Test
+    fun retryBackoff_mixErrorsAndSuccess() {
+        val timers = mutableListOf<MockTimer>()
+        var attempt: Int by atomic(0)
+        val timerFactory = MockTimerFactory { _, duration ->
+            when (timers.size) {
+                0 -> assertEquals(1.minutes, duration)
+                1 -> assertEquals(2.minutes, duration)
+            }
+            MockTimer().also { timers.add(it) }
+        }
+        val sourcePublisher1 = Publishers.behaviorSubject(0)
+        val sourcePublisher2 = Publishers.behaviorSubject(1)
+        val upStreamPublisher = ColdPublisher {
+            val result = when (val value = attempt) {
+                0 -> sourcePublisher1
+                1 -> sourcePublisher2
+                else -> value.just()
+            }
+            attempt = attempt + 1
+            result
+        }
+        val retryPublisher = upStreamPublisher.retryBackoff(
+            ExponentialBackoffPolicy(
+                initialInterval = 1.minutes,
+                maxRetries = 8,
+                maxInterval = 1.hours,
+                multiplier = 2.0
+            ),
+            timerFactory
+        )
+        val receivedResults = mutableListOf<Int>()
+        val receivedErrors = mutableListOf<Throwable>()
+        retryPublisher.subscribe(
+            CancellableManager(),
+            onNext = { receivedResults.add(it) },
+            onError = { receivedErrors.add(it) },
+            onCompleted = {}
+        )
+
+        assertEquals(listOf(0), receivedResults)
+        assertEquals(emptyList(), receivedErrors)
+
+        sourcePublisher1.error = Throwable()
+
+        assertEquals(1, timerFactory.singleCall)
+        timers[0].executeBlock()
+
+        assertEquals(listOf(0, 1), receivedResults)
+        assertEquals(emptyList(), receivedErrors)
+
+        sourcePublisher2.error = Throwable()
+
+        assertEquals(2, timerFactory.singleCall)
+        timers[1].executeBlock()
+
+        assertEquals(listOf(0, 1, 2), receivedResults)
+        assertEquals(emptyList(), receivedErrors)
+    }
+
+    @Test
+    fun retryBackoff_allErrors_withMaxRetries() {
+        val timers = mutableListOf<MockTimer>()
+        val timerFactory = MockTimerFactory { _, duration ->
+            when (timers.size) {
+                0 -> assertEquals(1.seconds, duration)
+                1 -> assertEquals(1.minutes, duration)
+                2 -> assertEquals(1.seconds, duration)
+                3 -> assertEquals(2.minutes, duration)
+                4 -> assertEquals(1.seconds, duration)
+                5 -> assertEquals(4.minutes, duration)
+                6 -> assertEquals(1.seconds, duration)
+                7 -> assertEquals(8.minutes, duration)
+            }
+            MockTimer().also { timers.add(it) }
+        }
+        val upStreamPublisher = ColdPublisher {
+            Publishers.error<Int>(Throwable()).delay(1.seconds, timerFactory)
+        }
+
+        val retryPublisher = upStreamPublisher.retryBackoff(
+            ExponentialBackoffPolicy(
+                initialInterval = 1.minutes,
+                maxRetries = 4,
+                maxInterval = 1.hours,
+                multiplier = 2.0
+            ),
+            timerFactory
+        )
+
+        val receivedResults = mutableListOf<Int>()
+        val receivedErrors = mutableListOf<Throwable>()
+        retryPublisher.subscribe(
+            CancellableManager(),
+            onNext = { receivedResults.add(it) },
+            onError = { receivedErrors.add(it) },
+            onCompleted = {}
+        )
+
+        assertEquals(emptyList(), receivedResults)
+        assertEquals(emptyList(), receivedErrors)
+
+        (0..8).forEach {
+            timers[it].executeBlock()
+        }
+
+        assertEquals(emptyList(), receivedResults)
+        assertEquals(1, receivedErrors.size)
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/backoff/ExponentialBackoffPolicyTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/backoff/ExponentialBackoffPolicyTests.kt
@@ -1,0 +1,59 @@
+package com.mirego.trikot.streams.reactive.backoff
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.hours
+import kotlin.time.minutes
+import kotlin.time.seconds
+
+class ExponentialBackoffPolicyTests {
+    @Test
+    fun exponentialBackoff_withMaxRetry() {
+        val backoffPolicy = ExponentialBackoffPolicy(
+            initialInterval = 1.minutes,
+            maxRetries = 8,
+            maxInterval = 1.hours,
+            multiplier = 2.0
+        )
+
+        (1..2).forEach { _ ->
+            val backoffs = (1..10).map { backoffPolicy.nextBackoff() }
+            assertBackoffDuration(1.minutes, backoffs[0])
+            assertBackoffDuration(2.minutes, backoffs[1])
+            assertBackoffDuration(4.minutes, backoffs[2])
+            assertBackoffDuration(8.minutes, backoffs[3])
+            assertBackoffDuration(16.minutes, backoffs[4])
+            assertBackoffDuration(32.minutes, backoffs[5])
+            assertBackoffDuration(1.hours, backoffs[6])
+            assertBackoffDuration(1.hours, backoffs[7])
+            assertBackoffStop(backoffs[8])
+            assertBackoffStop(backoffs[9])
+
+            backoffPolicy.reset()
+        }
+    }
+
+    @Test
+    fun exponentialBackoff_multiplierIsOneWithoutMaxRetry() {
+        val backoffPolicy = ExponentialBackoffPolicy(
+            initialInterval = 1.seconds,
+            maxInterval = Duration.INFINITE,
+            multiplier = 1.0
+        )
+        val backoffs = (1..1000).map { backoffPolicy.nextBackoff() }
+        backoffs.forEach {
+            assertBackoffDuration(1.seconds, it)
+        }
+    }
+
+    private fun assertBackoffDuration(duration: Duration, backoff: Backoff) {
+        assertTrue(backoff is Backoff.Next)
+        assertEquals(duration, backoff.duration)
+    }
+
+    private fun assertBackoffStop(backoff: Backoff) {
+        assertTrue(backoff is Backoff.Stop)
+    }
+}


### PR DESCRIPTION
## 📖 Description
I also added an extension to retry with backOff, it basically combines retryWhen, switchMap and timer. I was hesistant to add it here but it should be a good starting point.
For more advanced usage (retrying on certain errors, or only when network is available) the BackoffStrategy will be available standalone (it is actually my use case).

## 💭 Motivation and Context
This should be useful with http requests for instance to retry automatically and provide custom backoff strategy to reduce server load.

## 🧪 How Has This Been Tested?
Unit tested

## 🦀 Dispatch

#dispatch/kmp
