### PR TITLE
Add new RejectProcessor for Publishers

### DIFF
--- a/documentation/PUBLISHERS.md
+++ b/documentation/PUBLISHERS.md
@@ -130,6 +130,12 @@ Dispatch value only if it match the filter
 publisher.filter { it.length > 2 }
 ```
 
+#### Reject
+Dispatch value only if it doesn't match the filter (the opposite of `filter` processor)
+```kotlin
+publisher.reject { it.empty() }
+```
+
 #### SwitchMap
 *Input* - Value from previous processor
 *Output* - Publisher

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -23,6 +23,8 @@ import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextBlock
 import com.mirego.trikot.streams.reactive.processors.OnErrorResumeNextProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessor
 import com.mirego.trikot.streams.reactive.processors.OnErrorReturnProcessorBlock
+import com.mirego.trikot.streams.reactive.processors.RejectProcessor
+import com.mirego.trikot.streams.reactive.processors.RejectProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.RetryWhenProcessor
 import com.mirego.trikot.streams.reactive.processors.RetryWhenPublisherBlock
 import com.mirego.trikot.streams.reactive.processors.SampleProcessor
@@ -96,6 +98,10 @@ fun <T> Publisher<T>.withCancellableManager(): Publisher<WithCancellableManagerP
 
 fun <T> Publisher<T>.filter(block: FilterProcessorBlock<T>): Publisher<T> {
     return FilterProcessor(this, block)
+}
+
+fun <T> Publisher<T>.reject(block: RejectProcessorBlock<T>): Publisher<T> {
+    return RejectProcessor(this, block)
 }
 
 fun <T> Publisher<T>.shared(): Publisher<T> {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessor.kt
@@ -1,0 +1,21 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+typealias RejectProcessorBlock<T> = (T) -> Boolean
+
+class RejectProcessor<T>(parentPublisher: Publisher<T>, private val block: RejectProcessorBlock<T>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> {
+        return RejectProcessorSubscription(subscriber, block)
+    }
+
+    class RejectProcessorSubscription<T>(subscriber: Subscriber<in T>, val block: RejectProcessorBlock<T>) :
+        ProcessorSubscription<T, T>(subscriber) {
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            if (!block(t)) subscriber.onNext(t)
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/FilterProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/FilterProcessorTests.kt
@@ -10,21 +10,21 @@ import kotlin.test.assertEquals
 class FilterProcessorTests {
     @Test
     fun filterTrue() {
-        val publisher = Publishers.behaviorSubject("a")
+        val publisher = Publishers.behaviorSubject("a string")
         var value: String? = null
 
-        publisher.filter { true }.subscribe(CancellableManager()) {
+        publisher.filter { it.isNotBlank() }.subscribe(CancellableManager()) {
             value = it
         }
 
-        assertEquals("a", value)
+        assertEquals("a string", value)
     }
 
     @Test
     fun filterFalse() {
-        val publisher = Publishers.behaviorSubject("a")
+        val publisher = Publishers.behaviorSubject("")
         var value: String? = null
-        publisher.filter { false }.subscribe(CancellableManager()) {
+        publisher.filter { it.isNotBlank() }.subscribe(CancellableManager()) {
             value = it
         }
 

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessorTests.kt
@@ -10,10 +10,10 @@ import kotlin.test.assertEquals
 class RejectProcessorTests {
     @Test
     fun rejectTrue() {
-        val publisher = Publishers.behaviorSubject("a")
+        val publisher = Publishers.behaviorSubject("")
         var value: String? = null
 
-        publisher.reject { true }.subscribe(CancellableManager()) {
+        publisher.reject { it.isBlank() }.subscribe(CancellableManager()) {
             value = it
         }
 
@@ -22,13 +22,13 @@ class RejectProcessorTests {
 
     @Test
     fun rejectFalse() {
-        val publisher = Publishers.behaviorSubject("a")
+        val publisher = Publishers.behaviorSubject("a string")
         var value: String? = null
 
-        publisher.reject { false }.subscribe(CancellableManager()) {
+        publisher.reject { it.isBlank() }.subscribe(CancellableManager()) {
             value = it
         }
 
-        assertEquals("a", value)
+        assertEquals("a string", value)
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/RejectProcessorTests.kt
@@ -1,0 +1,34 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.reject
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RejectProcessorTests {
+    @Test
+    fun rejectTrue() {
+        val publisher = Publishers.behaviorSubject("a")
+        var value: String? = null
+
+        publisher.reject { true }.subscribe(CancellableManager()) {
+            value = it
+        }
+
+        assertEquals(null, value)
+    }
+
+    @Test
+    fun rejectFalse() {
+        val publisher = Publishers.behaviorSubject("a")
+        var value: String? = null
+
+        publisher.reject { false }.subscribe(CancellableManager()) {
+            value = it
+        }
+
+        assertEquals("a", value)
+    }
+}


### PR DESCRIPTION
## 📖 Description
🧠 New feature (non-breaking change which adds functionality)

We add a new Publisher Processor, `RejectProcessor`, which will dispatch the value only if it doesn't match the filter (which is the opposite behavior of the `FilterProcessor`)

## 💭 Motivation and Context
Usually, a code with less negativity in it is easier to read. This way, by using `reject` instead of `filter`, we can tell our publishers to dispatch a value only if it doesn't match the filter we are applying.

E.g We want a `Publisher<String>` to dispatch only values that are not blank. With `reject`, we can write : 
```
publisher.reject { it.isBlank() }
```
instead of
```
publisher.filter { !it.isBlank() }
```

## 🧪 How Has This Been Tested?
Unit tests have been added to support the new Processor.
This shouldn't affect any other areas of the code

## 🦀 Dispatch
- `#dispatch/kmp`
