### PR TITLE
Update Kotlin to version 1.5.10 and add watchOS and macOS targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.2")
+        classpath("com.android.tools.build:gradle:4.1.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${project.extra["kotlin_version"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 kotlin.code.style=official
-kotlin_version=1.5.0
+kotlin_version=1.5.10
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=2.1.0
+trikot_foundation_version=2.2.0
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/streams/build.gradle.kts
+++ b/streams/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
+    watchos()
+    macosX64()
     js(IR) {
         browser()
     }
@@ -108,6 +110,22 @@ kotlin {
         }
 
         val tvosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchos32Main by creating {
+            dependsOn(nativeMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(watchos32Main)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val macosX64Main by getting {
             dependsOn(nativeMain)
         }
     }

--- a/streams/gradle.properties
+++ b/streams/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 10 16:05:13 EDT 2021
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT


### PR DESCRIPTION
## 📖 Description
- Added watchOS and macOS targets
- Updated Kotlin version to 1.5.10

## 💭 Motivation and Context
macOS target was needed for a project

## 🧪 How Has This Been Tested?
`./gradlew build`

## 🦀 Dispatch
`#dispatch/kmp`
