### PR TITLE
Fix possible race condition with the first processor

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/FirstProcessor.kt
@@ -15,15 +15,16 @@ class FirstProcessor<T>(parentPublisher: Publisher<T>) :
         private val hasReceivedValue = AtomicReference(false)
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             if (t != null) {
-                hasReceivedValue.compareAndSet(false, true)
-                cancelActiveSubscription()
-                subscriber.onNext(t)
-                subscriber.onComplete()
+                if (hasReceivedValue.compareAndSet(false, true)) {
+                    cancelActiveSubscription()
+                    subscriber.onNext(t)
+                    subscriber.onComplete()
+                }
             }
         }
 
         override fun onComplete() {
-            if (!hasReceivedValue.value) {
+            if (hasReceivedValue.compareAndSet(false, true)) {
                 super.onComplete()
             }
         }


### PR DESCRIPTION
## 📖 Description
<!-- 🐛 Bug fix (non-breaking change which fixes an issue) -->

When the first publisher receives a value in onNext subscriber method, it cancels its active subscription to make tell the parentPublisher to stops sending event. Our implementation is shielding us from this but we may have other processors that will behave differently (if they are platform wrappers or other ReactiveStream.publisher implementation.

To make sure we respect the contract of the first publisher, we enforce that only one value and one completion is emitted using the AtomicReference.

## 💭 Motivation and Context
I am tracking a bug where a value is set after a publisher has been completed when a reactive flow contains first and the publisher is subscribing on another thread.

## 🧪 How Has This Been Tested?
Not tested.

## 🦀 Dispatch
- `#dispatch/kmp`
