### PR TITLE
Implement takeWhile operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -256,8 +256,8 @@ fun <T> Publisher<T>.retryBackoff(
 }
 
 /**
- * The TakeWhile mirrors the source Observable until a specified condition becomes false,
- * at which point TakeWhile stops mirroring the source Observable and terminates its own Observable.
+ * The TakeWhile mirrors the source Publisher until a specified condition becomes false,
+ * at which point TakeWhile stops mirroring the source Publisher and complete its own Publisher.
  *
  * Marbles diagram :
  * -------(1)---(2)-----(3)-----(4)--|->

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -35,6 +35,8 @@ import com.mirego.trikot.streams.reactive.processors.SkipProcessor
 import com.mirego.trikot.streams.reactive.processors.SubscribeOnProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessorBlock
+import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessor
+import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessorPredicate
 import com.mirego.trikot.streams.reactive.processors.ThreadLocalProcessor
 import com.mirego.trikot.streams.reactive.processors.TimeoutProcessor
 import com.mirego.trikot.streams.reactive.processors.WithCancellableManagerProcessor
@@ -251,4 +253,20 @@ fun <T> Publisher<T>.retryBackoff(
             is Backoff.Next -> Publishers.timer(backoff.duration, timerFactory)
         }
     }
+}
+
+// mirror items emitted by an Observable until a specified condition becomes false
+/**
+ * The TakeWhile mirrors the source Observable until such time as some condition you specify becomes false,
+ * at which point TakeWhile stops mirroring the source Observable and terminates its own Observable.
+ *
+ * Marbles diagram :
+ * -------(1)---(2)-----(3)-----(4)--|->
+ * takeWhile(!=3)
+ * -------(1)---(2)------|------------->
+ *
+ * @see @see <a href="http://reactivex.io/documentation/operators/takewhile.html">http://reactivex.io/documentation/operators/takewhile.html</a>
+ */
+fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publisher<T> {
+    return TakeWhileProcessor(this, predicate)
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -255,9 +255,8 @@ fun <T> Publisher<T>.retryBackoff(
     }
 }
 
-// mirror items emitted by an Observable until a specified condition becomes false
 /**
- * The TakeWhile mirrors the source Observable until such time as some condition you specify becomes false,
+ * The TakeWhile mirrors the source Observable until a specified condition becomes false,
  * at which point TakeWhile stops mirroring the source Observable and terminates its own Observable.
  *
  * Marbles diagram :

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -264,7 +264,7 @@ fun <T> Publisher<T>.retryBackoff(
  * takeWhile(!=3)
  * -------(1)---(2)------|------------->
  *
- * @see @see <a href="http://reactivex.io/documentation/operators/takewhile.html">http://reactivex.io/documentation/operators/takewhile.html</a>
+ * @see <a href="http://reactivex.io/documentation/operators/takewhile.html">http://reactivex.io/documentation/operators/takewhile.html</a>
  */
 fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publisher<T> {
     return TakeWhileProcessor(this, predicate)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
@@ -42,9 +42,9 @@ class TakeWhileProcessor<T>(
         }
 
         override fun onComplete() {
-            if (!hasCompleted) {
-                super.onComplete()
-            }
+            if (hasCompleted) return
+            hasCompleted = true
+            super.onComplete()
         }
     }
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
@@ -10,8 +10,7 @@ typealias TakeWhileProcessorPredicate<T> = (T) -> Boolean
 class TakeWhileProcessor<T>(
     parentPublisher: Publisher<T>,
     private val predicate: TakeWhileProcessorPredicate<T>
-) :
-    AbstractProcessor<T, T>(parentPublisher) {
+) : AbstractProcessor<T, T>(parentPublisher) {
 
     override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> =
         TakeWhileProcessorSubscription(subscriber, predicate)

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
@@ -7,7 +7,10 @@ import org.reactivestreams.Subscriber
 
 typealias TakeWhileProcessorPredicate<T> = (T) -> Boolean
 
-class TakeWhileProcessor<T>(parentPublisher: Publisher<T>, private val predicate: TakeWhileProcessorPredicate<T>) :
+class TakeWhileProcessor<T>(
+    parentPublisher: Publisher<T>,
+    private val predicate: TakeWhileProcessorPredicate<T>
+) :
     AbstractProcessor<T, T>(parentPublisher) {
 
     override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> =
@@ -18,7 +21,7 @@ class TakeWhileProcessor<T>(parentPublisher: Publisher<T>, private val predicate
         private val predicate: TakeWhileProcessorPredicate<T>
     ) : ProcessorSubscription<T, T>(subscriber) {
 
-        private var hasCompleted : Boolean by atomic(false)
+        private var hasCompleted: Boolean by atomic(false)
 
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
             if (hasCompleted) return

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessor.kt
@@ -1,0 +1,48 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+typealias TakeWhileProcessorPredicate<T> = (T) -> Boolean
+
+class TakeWhileProcessor<T>(parentPublisher: Publisher<T>, private val predicate: TakeWhileProcessorPredicate<T>) :
+    AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> =
+        TakeWhileProcessorSubscription(subscriber, predicate)
+
+    class TakeWhileProcessorSubscription<T>(
+        subscriber: Subscriber<in T>,
+        private val predicate: TakeWhileProcessorPredicate<T>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+
+        private var hasCompleted : Boolean by atomic(false)
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            if (hasCompleted) return
+
+            val result = try {
+                predicate(t)
+            } catch (exception: StreamsProcessorException) {
+                onError(exception)
+                return
+            }
+
+            if (result) {
+                subscriber.onNext(t)
+            } else {
+                hasCompleted = true
+                cancelActiveSubscription()
+                subscriber.onComplete()
+            }
+        }
+
+        override fun onComplete() {
+            if (!hasCompleted) {
+                super.onComplete()
+            }
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
@@ -224,16 +224,8 @@ class TakeWhileProcessorTests {
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
 
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        var receivedException: StreamsProcessorException? = null
-
         assertFailsWith(IllegalStateException::class) {
-            publisher.takeWhile { throw IllegalStateException() }.subscribe(
-                CancellableManager(),
-                onNext = {
-                },
-                onError = { receivedException = it as StreamsProcessorException }
-            )
+            publisher.takeWhile { throw IllegalStateException() }.subscribe(CancellableManager()) {}
         }
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
@@ -1,0 +1,191 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.subscribe
+import com.mirego.trikot.streams.reactive.takeWhile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TakeWhileProcessorTests {
+
+    @Test
+    fun testTakeWhile() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .takeWhile { it != 3 }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+
+        assertEquals(listOf(0, 1, 2), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testReconnectionWithoutFalsePredicate() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeWhilePublisher = publisher.takeWhile { it != "d" }
+
+        val cancellableManager1 = CancellableManager()
+        val cancellableManager2 = CancellableManager()
+
+        takeWhilePublisher
+            .subscribe(cancellableManager1) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager1.cancel()
+
+        takeWhilePublisher
+            .subscribe(cancellableManager2) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager2.cancel()
+
+        assertEquals(listOf("a", "b", "c", "a", "b", "c"), receivedResults)
+    }
+
+    @Test
+    fun testReconnectionWithFalsePredicate() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeWhilePublisher = publisher.takeWhile { it != "c" }
+
+        val cancellableManager1 = CancellableManager()
+        val cancellableManager2 = CancellableManager()
+
+        takeWhilePublisher
+            .subscribe(cancellableManager1) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        takeWhilePublisher
+            .subscribe(cancellableManager2) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        assertEquals(listOf("a", "b", "a", "b"), receivedResults)
+    }
+
+    @Test
+    fun testShouldCompleteIfPredicateIsFalse() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeWhilePublisher = publisher.takeWhile { it != "b" }
+
+        var firstCompletion = false
+        var secondCompletion = false
+
+        takeWhilePublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    firstCompletion = true
+                }
+            )
+
+        publisher.value = "a"
+        publisher.value = "b"
+
+        takeWhilePublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    secondCompletion = true
+                }
+            )
+
+        publisher.value = "a"
+        publisher.value = "b"
+
+        assertTrue(firstCompletion)
+        assertTrue(secondCompletion)
+    }
+
+    @Test
+    fun testMappingStreamsProcessorException() {
+        val publisher = Publishers.behaviorSubject("a")
+        val expectedException = StreamsProcessorException()
+        var receivedException: StreamsProcessorException? = null
+
+        publisher.takeWhile { throw expectedException }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                },
+                onError = {
+                    receivedException = it as StreamsProcessorException
+                }
+            )
+
+        assertEquals(expectedException, receivedException)
+    }
+
+    @Test
+    fun testMappingAnyException() {
+        val publisher = Publishers.behaviorSubject("a")
+
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        var receivedException: StreamsProcessorException? = null
+
+        assertFailsWith(IllegalStateException::class) {
+            publisher.takeWhile { throw IllegalStateException() }.subscribe(
+                CancellableManager(),
+                onNext = {
+                },
+                onError = { receivedException = it as StreamsProcessorException }
+            )
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeWhileProcessorTests.kt
@@ -42,7 +42,55 @@ class TakeWhileProcessorTests {
     }
 
     @Test
-    fun testReconnectionWithoutFalsePredicate() {
+    fun testCompletionBehaviorWhenPredicateIsTrueAndSourcePublisherIsCompleted() {
+        val publisher = Publishers.just(true)
+        val receivedResults = mutableListOf<Boolean>()
+        var completed = false
+
+        publisher
+            .takeWhile { it }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        assertEquals(listOf(true), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testCompletionBehaviorWhenPredicateIsFalseAndSourcePublisherIsCompleted() {
+        val publisher = Publishers.just(false)
+        val receivedResults = mutableListOf<Boolean>()
+        var completed = false
+
+        publisher
+            .takeWhile { it }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        assertEquals(emptyList(), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testReconnectionWhenPredicateIsAlwaysTrue() {
         val publisher = Publishers.publishSubject<String>()
         val receivedResults = mutableListOf<String>()
 
@@ -77,7 +125,7 @@ class TakeWhileProcessorTests {
     }
 
     @Test
-    fun testReconnectionWithFalsePredicate() {
+    fun testReconnectionWhenPredicateIsFalse() {
         val publisher = Publishers.publishSubject<String>()
         val receivedResults = mutableListOf<String>()
 


### PR DESCRIPTION
## Description
This implements the takeWhile operator based on the reactive spec.

_mirror items emitted by an Observable until a specified condition becomes false_
<img width="640" alt="takeWhile c" src="https://user-images.githubusercontent.com/6673075/124602566-fbdb8500-de36-11eb-82d6-225b12344cd6.png">
Source: http://reactivex.io/documentation/operators/takewhile.html

## How Has This Been Tested?
Unit tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## 🦀 Dispatch
- `#dispatch/kmp`
