### PR TITLE
Implement takeUntil operator

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -37,6 +37,8 @@ import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessorBlock
 import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessor
 import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessorPredicate
+import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessor
+import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessorPredicate
 import com.mirego.trikot.streams.reactive.processors.ThreadLocalProcessor
 import com.mirego.trikot.streams.reactive.processors.TimeoutProcessor
 import com.mirego.trikot.streams.reactive.processors.WithCancellableManagerProcessor
@@ -268,4 +270,19 @@ fun <T> Publisher<T>.retryBackoff(
  */
 fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publisher<T> {
     return TakeWhileProcessor(this, predicate)
+
+/**
+ * The TakeUntil uses a predicate function that evaluates the items emitted by the source Publisher
+ * to terminate if we mirrors the source OR emit one last item and complete immediately after.
+ *
+ * Marbles diagram :
+ * -------(1)---(2)-----(3)-----(4)--|->
+ * takeUntil(==3)
+ * -------(1)---(2)-----(3)/----------->
+ *
+ * @see @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">http://reactivex.io/documentation/operators/takeuntil.html</a>
+ * This is the predicate version, rather than receiving a second Publisher
+ */
+fun <T> Publisher<T>.takeUntil(predicate: TakeUntilProcessorPredicate<T>): Publisher<T> {
+    return TakeUntilProcessor(this, predicate)
 }

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -270,6 +270,7 @@ fun <T> Publisher<T>.retryBackoff(
  */
 fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publisher<T> {
     return TakeWhileProcessor(this, predicate)
+}
 
 /**
  * The TakeUntil uses a predicate function that evaluates the items emitted by the source Publisher

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -35,10 +35,10 @@ import com.mirego.trikot.streams.reactive.processors.SkipProcessor
 import com.mirego.trikot.streams.reactive.processors.SubscribeOnProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessor
 import com.mirego.trikot.streams.reactive.processors.SwitchMapProcessorBlock
-import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessor
-import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessorPredicate
 import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessor
 import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessorPredicate
+import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessor
+import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessorPredicate
 import com.mirego.trikot.streams.reactive.processors.ThreadLocalProcessor
 import com.mirego.trikot.streams.reactive.processors.TimeoutProcessor
 import com.mirego.trikot.streams.reactive.processors.WithCancellableManagerProcessor

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -280,7 +280,7 @@ fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publi
  * takeUntil(==3)
  * -------(1)---(2)-----(3)/----------->
  *
- * @see @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">http://reactivex.io/documentation/operators/takeuntil.html</a>
+ * @see <a href="http://reactivex.io/RxJava/javadoc/rx/Observable.html#takeUntil-rx.functions.Func1-">http://reactivex.io/RxJava/javadoc/rx/Observable.html#takeUntil-rx.functions.Func1-</a>
  * This is the predicate version, rather than receiving a second Publisher
  */
 fun <T> Publisher<T>.takeUntil(predicate: TakeUntilProcessorPredicate<T>): Publisher<T> {

--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessor.kt
@@ -1,0 +1,49 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+typealias TakeUntilProcessorPredicate<T> = (T) -> Boolean
+
+class TakeUntilProcessor<T>(
+    parentPublisher: Publisher<T>,
+    private val predicate: TakeUntilProcessorPredicate<T>
+) : AbstractProcessor<T, T>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in T>): ProcessorSubscription<T, T> =
+        TakeUntilProcessorSubscription(subscriber, predicate)
+
+    class TakeUntilProcessorSubscription<T>(
+        subscriber: Subscriber<in T>,
+        private val predicate: TakeUntilProcessorPredicate<T>
+    ) : ProcessorSubscription<T, T>(subscriber) {
+
+        private var hasCompleted: Boolean by atomic(false)
+
+        override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            if (hasCompleted) return
+            subscriber.onNext(t)
+
+            val result = try {
+                predicate(t)
+            } catch (exception: StreamsProcessorException) {
+                onError(exception)
+                return
+            }
+
+            if (result) {
+                hasCompleted = true
+                cancelActiveSubscription()
+                subscriber.onComplete()
+            }
+        }
+
+        override fun onComplete() {
+            if (hasCompleted) return
+            hasCompleted = true
+            super.onComplete()
+        }
+    }
+}

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
@@ -42,6 +42,54 @@ class TakeUntilProcessorTests {
     }
 
     @Test
+    fun testCompletionBehaviorWhenPredicateIsTrueAndSourcePublisherIsCompleted() {
+        val publisher = Publishers.just(true)
+        val receivedResults = mutableListOf<Boolean>()
+        var completed = false
+
+        publisher
+            .takeUntil { it }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        assertEquals(listOf(true), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testCompletionBehaviorWhenPredicateIsFalseAndSourcePublisherIsCompleted() {
+        val publisher = Publishers.just(false)
+        val receivedResults = mutableListOf<Boolean>()
+        var completed = false
+
+        publisher
+            .takeUntil { it }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        assertEquals(listOf(false), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
     fun testReconnectionWithTruePredicate() {
         val publisher = Publishers.publishSubject<String>()
         val receivedResults = mutableListOf<String>()

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
@@ -178,16 +178,8 @@ class TakeUntilProcessorTests {
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
 
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-        var receivedException: StreamsProcessorException? = null
-
         assertFailsWith(IllegalStateException::class) {
-            publisher.takeUntil { throw IllegalStateException() }.subscribe(
-                CancellableManager(),
-                onNext = {
-                },
-                onError = { receivedException = it as StreamsProcessorException }
-            )
+            publisher.takeUntil { throw IllegalStateException() }.subscribe(CancellableManager()) {}
         }
     }
 }

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/TakeUntilProcessorTests.kt
@@ -1,0 +1,193 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.subscribe
+import com.mirego.trikot.streams.reactive.takeUntil
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TakeUntilProcessorTests {
+
+    @Test
+    fun testTakeUntil() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .takeUntil { it == 3 }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+
+        assertEquals(listOf(0, 1, 2, 3), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testReconnectionWithTruePredicate() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeUntilPublisher = publisher.takeUntil { it == "c" }
+
+        val cancellableManager1 = CancellableManager()
+        val cancellableManager2 = CancellableManager()
+
+        takeUntilPublisher
+            .subscribe(cancellableManager1) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+        publisher.value = "d"
+
+        takeUntilPublisher
+            .subscribe(cancellableManager2) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+        publisher.value = "d"
+
+        assertEquals(listOf("a", "b", "c", "a", "b", "c"), receivedResults)
+    }
+
+    @Test
+    fun testReconnectionWithoutTruePredicate() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeUntilPublisher = publisher.takeUntil { it == "d" }
+
+        val cancellableManager1 = CancellableManager()
+        val cancellableManager2 = CancellableManager()
+
+        takeUntilPublisher
+            .subscribe(cancellableManager1) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager1.cancel()
+
+        takeUntilPublisher
+            .subscribe(cancellableManager2) {
+                receivedResults.add(it)
+            }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager2.cancel()
+
+        assertEquals(listOf("a", "b", "c", "a", "b", "c"), receivedResults)
+    }
+
+    @Test
+    fun testShouldCompleteIfPredicateIsTrue() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val takeUntilPublisher = publisher.takeUntil { it == "b" }
+
+        var firstCompletion = false
+        var secondCompletion = false
+
+        takeUntilPublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    firstCompletion = true
+                }
+            )
+
+        publisher.value = "a"
+        publisher.value = "b"
+
+        takeUntilPublisher
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    secondCompletion = true
+                }
+            )
+
+        publisher.value = "a"
+        publisher.value = "b"
+
+        assertTrue(firstCompletion)
+        assertTrue(secondCompletion)
+    }
+
+    @Test
+    fun testMappingStreamsProcessorException() {
+        val publisher = Publishers.behaviorSubject("a")
+        val expectedException = StreamsProcessorException()
+        var receivedException: StreamsProcessorException? = null
+
+        publisher.takeUntil { throw expectedException }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                },
+                onError = {
+                    receivedException = it as StreamsProcessorException
+                }
+            )
+
+        assertEquals(expectedException, receivedException)
+    }
+
+    @Test
+    fun testMappingAnyException() {
+        val publisher = Publishers.behaviorSubject("a")
+
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        var receivedException: StreamsProcessorException? = null
+
+        assertFailsWith(IllegalStateException::class) {
+            publisher.takeUntil { throw IllegalStateException() }.subscribe(
+                CancellableManager(),
+                onNext = {
+                },
+                onError = { receivedException = it as StreamsProcessorException }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
This implements the takeUntil operator based on the reactive spec (this is the predicate version). It uses a predicate that evaluates the items emitted by the source Observable to terminate the resulting Observable sequence. In this way, it behaves in a similar way to [TakeWhile](https://github.com/mirego/trikot.streams/pull/109).

<img width="640" alt="takeUntil p" src="https://user-images.githubusercontent.com/6673075/124602953-6e4c6500-de37-11eb-8063-0bbca895bd80.png">
Source: http://reactivex.io/documentation/operators/takeuntil.html

## How Has This Been Tested?
Unit tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## 🦀 Dispatch
- `#dispatch/kmp`
