### PR TITLE
Bugfix - SwitchMap inner publisher cancellation order

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessor.kt
@@ -46,6 +46,8 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
             onNextValidation.setOrThrow(0, 1)
             isChildCompleted.setOrThrow(isChildCompleted.value, false)
 
+            val cancellableManager = cancellableManagerProvider.cancelPreviousAndCreate()
+
             val newPublisher = try {
                 block(t)
             } catch (e: StreamsProcessorException) {
@@ -55,7 +57,7 @@ class SwitchMapProcessor<T, R>(parentPublisher: Publisher<T>, private var block:
 
             currentPublisher.setOrThrow(currentPublisher.value, newPublisher)
             newPublisher.observeOn(serialQueue).subscribe(
-                cancellableManagerProvider.cancelPreviousAndCreate(),
+                cancellableManager,
                 onNext = { subscriber.onNext(it) },
                 onError = {
                     onError(it)

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
@@ -21,12 +21,14 @@ class SwitchMapProcessorTests {
         var receivedValueSwitchMap: String? = null
         var receivedValueSubscription: String? = null
 
-        switchMappedPublisher.switchMap {
-            receivedValueSwitchMap = it
-            returnedPublisher
-        }.subscribe(CancellableManager()) {
-            receivedValueSubscription = it
-        }
+        switchMappedPublisher
+            .switchMap {
+                receivedValueSwitchMap = it
+                returnedPublisher
+            }
+            .subscribe(CancellableManager()) {
+                receivedValueSubscription = it
+            }
 
         assertEquals("a", receivedValueSwitchMap)
         assertEquals("b", receivedValueSubscription)
@@ -38,10 +40,9 @@ class SwitchMapProcessorTests {
         val returnedPublisher = MockPublisher()
         val cancellableManager = CancellableManager()
 
-        switchMappedPublisher.switchMap {
-            returnedPublisher
-        }.subscribe(cancellableManager) {
-        }
+        switchMappedPublisher
+            .switchMap { returnedPublisher }
+            .subscribe(cancellableManager) {}
 
         cancellableManager.cancel()
 
@@ -54,12 +55,14 @@ class SwitchMapProcessorTests {
         val returnedPublisher = Publishers.behaviorSubject("b")
         var isCompleted = false
 
-        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(
-            CancellableManager(),
-            onNext = {},
-            onError = {},
-            onCompleted = { isCompleted = true }
-        )
+        switchMappedPublisher
+            .switchMap { returnedPublisher }
+            .subscribe(
+                CancellableManager(),
+                onNext = {},
+                onError = {},
+                onCompleted = { isCompleted = true }
+            )
         switchMappedPublisher.complete()
         assertFalse { isCompleted }
     }
@@ -70,12 +73,14 @@ class SwitchMapProcessorTests {
         val returnedPublisher = Publishers.behaviorSubject("b")
         var isCompleted = false
 
-        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(
-            CancellableManager(),
-            onNext = {},
-            onError = {},
-            onCompleted = { isCompleted = true }
-        )
+        switchMappedPublisher
+            .switchMap { returnedPublisher }
+            .subscribe(
+                CancellableManager(),
+                onNext = {},
+                onError = {},
+                onCompleted = { isCompleted = true }
+            )
         returnedPublisher.complete()
         assertFalse { isCompleted }
     }
@@ -86,12 +91,14 @@ class SwitchMapProcessorTests {
         val returnedPublisher = Publishers.behaviorSubject("b")
         var isCompleted = false
 
-        switchMappedPublisher.switchMap { returnedPublisher }.subscribe(
-            CancellableManager(),
-            onNext = {},
-            onError = {},
-            onCompleted = { isCompleted = true }
-        )
+        switchMappedPublisher
+            .switchMap { returnedPublisher }
+            .subscribe(
+                CancellableManager(),
+                onNext = {},
+                onError = {},
+                onCompleted = { isCompleted = true }
+            )
         switchMappedPublisher.complete()
         returnedPublisher.complete()
         assertTrue { isCompleted }
@@ -103,12 +110,13 @@ class SwitchMapProcessorTests {
         val expectedException = StreamsProcessorException()
         var receivedException: StreamsProcessorException? = null
 
-        publisher.switchMap<String, String> { throw expectedException }.subscribe(
-            CancellableManager(),
-            onNext = {
-            },
-            onError = { receivedException = it as StreamsProcessorException }
-        )
+        publisher
+            .switchMap<String, String> { throw expectedException }
+            .subscribe(
+                CancellableManager(),
+                onNext = {},
+                onError = { receivedException = it as StreamsProcessorException }
+            )
 
         assertEquals(expectedException, receivedException)
     }
@@ -119,12 +127,13 @@ class SwitchMapProcessorTests {
         var receivedException: StreamsProcessorException? = null
 
         assertFailsWith(IllegalStateException::class) {
-            publisher.switchMap<String, String> { throw IllegalStateException() }.subscribe(
-                CancellableManager(),
-                onNext = {
-                },
-                onError = { receivedException = it as StreamsProcessorException }
-            )
+            publisher
+                .switchMap<String, String> { throw IllegalStateException() }
+                .subscribe(
+                    CancellableManager(),
+                    onNext = {},
+                    onError = { receivedException = it as StreamsProcessorException }
+                )
         }
 
         assertEquals(null, receivedException)
@@ -136,7 +145,8 @@ class SwitchMapProcessorTests {
         val childPublisher = Publishers.behaviorSubject("a").also { it.error = Throwable() }
 
         var errorCallCount = 0
-        publisher.switchMap { childPublisher }
+        publisher
+            .switchMap { childPublisher }
             .subscribe(CancellableManager(), {}, { errorCallCount++ })
         publisher.value = "b"
 
@@ -152,10 +162,12 @@ class SwitchMapProcessorTests {
             Publishers.behaviorSubject(1)
         })
 
-        publisher.switchMap {
-            refreshablePublisher.refresh()
-            refreshablePublisher
-        }.subscribe(CancellableManager()) {}
+        publisher
+            .switchMap {
+                refreshablePublisher.refresh()
+                refreshablePublisher
+            }
+            .subscribe(CancellableManager()) {}
 
         publisher.value = "b"
 

--- a/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
+++ b/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/SwitchMapProcessorTests.kt
@@ -58,7 +58,8 @@ class SwitchMapProcessorTests {
             CancellableManager(),
             onNext = {},
             onError = {},
-            onCompleted = { isCompleted = true })
+            onCompleted = { isCompleted = true }
+        )
         switchMappedPublisher.complete()
         assertFalse { isCompleted }
     }
@@ -73,7 +74,8 @@ class SwitchMapProcessorTests {
             CancellableManager(),
             onNext = {},
             onError = {},
-            onCompleted = { isCompleted = true })
+            onCompleted = { isCompleted = true }
+        )
         returnedPublisher.complete()
         assertFalse { isCompleted }
     }
@@ -88,7 +90,8 @@ class SwitchMapProcessorTests {
             CancellableManager(),
             onNext = {},
             onError = {},
-            onCompleted = { isCompleted = true })
+            onCompleted = { isCompleted = true }
+        )
         switchMappedPublisher.complete()
         returnedPublisher.complete()
         assertTrue { isCompleted }


### PR DESCRIPTION
## 📖 Description
This fixes an issue in `SwitchMap`. The cancel on the previous publisher was done AFTER subscribing to the new publisher.

According to the RX Spec, cancellation on previous publisher must take place before the new publisher subscription.
See https://github.com/ReactiveX/RxJava/blob/3.x/src/main/java/io/reactivex/rxjava3/internal/operators/observable/ObservableSwitchMap.java for details about implementation.

With a combinaison of RefreshablePublisher that our refresh to be triggered twice in a row (once in refresh and once in onFirstSubscription). Since we now cancel before refresh is called, only the one in onFirstSubscription is left.

## 💭 Motivation and Context
It caused issues combined to other types of Publishers.

## 🧪 How Has This Been Tested?
Unit tested and it fixes our issue where we had double execution of our refresh block.

## 🦀 Dispatch
- `#dispatch/kmp`
