### PR TITLE
Fix risk of concurency in the sample processor

### DIFF
--- a/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SampleProcessor.kt
+++ b/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SampleProcessor.kt
@@ -33,7 +33,9 @@ class SampleProcessor<T>(
             val cancellableManager = cancellableManagerProvider.cancelPreviousAndCreate()
 
             val recurringTimer = timerFactory.repeatable(interval) {
-                dispatchSampledValue()
+                synchronousSerialQueue.dispatch {
+                    dispatchSampledValue()
+                }
             }
 
             cancellableManager.add { recurringTimer.cancel() }


### PR DESCRIPTION
## 📖 Description
🐛 Bug fix (non-breaking change which fixes an issue)

There is a possible race condition when the value is dispatched by the timer and when it is set. This was flagged in the original PR #91, but the change hasn't been made, it's on me, sorry. 

The dispatch is now made in the same serial dispatch queue than the value assigned to the publisher.

## 💭 Motivation and Context
We had a crash on fast sampling into our application, and realized that the request change about the dispatch queue hasn't been made.

## 🧪 How Has This Been Tested?
Not tested.

## 🦀 Dispatch
<!--- If needed, please specify the dispatch stack for which to suggest appropriate reviewers. -->
- `#dispatch/kmp`
